### PR TITLE
Time Dependencies

### DIFF
--- a/include/ArrayReference.hpp
+++ b/include/ArrayReference.hpp
@@ -4,236 +4,76 @@
 #include "./Math.hpp"
 #include "./Symbolics.hpp"
 #include <cstdint>
-#include <memory>
+#include <llvm/ADT/IntrusiveRefCntPtr.h>
+#include <llvm/ADT/SmallVector.h>
 
 // Stride terms are sorted based on VarID
 // NOTE: we require all Const sources be folded into the Affine, and their ids
 // set identically. thus, `getCount(VarType::Constant)` must always return
 // either `0` or `1`.
 struct Stride {
-    MPoly stride;
-    // sources must be ordered
-    llvm::SmallVector<std::pair<MPoly, VarID>, 1> indices;
-    Stride() = default;
-    Stride(MPoly const &x) : stride(x){};
-    Stride(MPoly &&x) : stride(std::move(x)){};
-    Stride(MPoly const &x, VarID ind) : indices({std::make_pair(x, ind)}){};
-    Stride(MPoly &x, uint32_t indId, VarType indTyp)
-        : indices({std::make_pair(x, VarID(indId, indTyp))}){};
-    Stride(MPoly stride, llvm::SmallVector<std::pair<MPoly, VarID>, 1> indices)
-        : stride(std::move(stride)), indices(std::move(indices)){};
-    Stride(Polynomial::Monomial stride,
-           llvm::SmallVector<std::pair<MPoly, VarID>, 1> indices)
-        : stride(MPoly{Polynomial::Term{int64_t(1), std::move(stride)}}),
-          indices(std::move(indices)){};
-    size_t size() const { return indices.size(); }
-    // size_t getCount(VarType i) {
-    //     return counts[size_t(i) + 1] - counts[size_t(i)];
-    // }
-    // size_t getCount(VarID i) { return getCount(i.getType()); }
-    inline auto begin() { return indices.begin(); }
-    inline auto end() { return indices.end(); }
-    inline auto begin() const { return indices.begin(); }
-    inline auto end() const { return indices.end(); }
-    inline auto cbegin() const { return indices.begin(); }
-    inline auto cend() const { return indices.end(); }
-    // inline auto begin(VarType i) { return indices.begin() +
-    // counts[size_t(i)]; } inline auto end(VarType i) {
-    //     return indices.begin() + counts[size_t(i) + 1];
-    // }
-    // inline auto begin(VarID i) { return begin(i.getType()); }
-    // inline auto end(VarID i) { return end(i.getType()); }
-    // inline auto begin(VarType i) const {
-    //     return indices.begin() + counts[size_t(i)];
-    // }
-    // inline auto end(VarType i) const {
-    //     return indices.begin() + counts[size_t(i) + 1];
-    // }
-    // inline auto begin(VarID i) const { return begin(i.getType()); }
-    // inline auto end(VarID i) const { return end(i.getType()); }
-    inline size_t numIndices() const { return indices.size(); }
-    auto &operator[](size_t i) { return indices[i]; }
-    auto &operator[](size_t i) const { return indices[i]; }
-    // MPoly indToPoly() const {
-    //     if (indices.size()) {
-    //         auto I = indices.begin();
-    //         MPoly p = (I->first) * (Polynomial::Monomial(I->second));
-    // 	    ++I;
-    // 	    for (; I != indices.end(); ++I){
-    // 		p +=
-    // 	    }
-    //         return p;
-    //     } else {
-    //         return {};
-    //     }
-    // }
-    bool allConstantIndices() const {
-        for (auto &&ind : indices) {
-            if (!ind.first.isCompileTimeConstant()) {
-                return false;
-            }
-        }
-        return true;
-    }
-    // void addTyp(VarType t) {
-    //     // Clang goes extremely overboard vectorizing loops with dynamic
-    //     length
-    //     // even if it should be statically inferrable that num iterations <=
-    //     4
-    //     // thus, static length + masking is preferable.
-    //     // GCC also seems to prefer this.
-    //     // https://godbolt.org/z/Pcxd6jre7
-    //     for (size_t i = 0; i < 4; ++i) {
-    //         counts[i + 1] += (size_t(t) <= i);
-    //     }
-    // }
-    // void remTyp(VarType t) {
-    //     for (size_t i = 0; i < 4; ++i) {
-    //         counts[i + 1] -= (size_t(t) <= i);
-    //     }
-    // }
-    // void addTyp(VarID t) { addTyp(t.getType()); }
-    // void remTyp(VarID t) { remTyp(t.getType()); }
+    const std::pair<MPoly, MPoly> *strideAndOffset;
+    const int64_t *inds;
+    const size_t dim;
 
-    template <typename A, typename I> void addTerm(A &&x, I &&ind) {
-        auto it = begin();
-        auto ite = end();
-        auto indTyp = ind.getType();
-        bool notFound = true;
-        for (; it != ite; ++it) {
-            bool typeMisMatch = (it->second).getType() != indTyp;
-            if (typeMisMatch & notFound) {
-                continue;
-            } else if (typeMisMatch || (ind < (it->second))) {
-                indices.insert(it, std::make_pair(std::forward<A>(x),
-                                                  std::forward<I>(ind)));
-                return;
-            } else if (ind == (it->second)) {
-                (it->first) += x;
-                if (isZero((it->first))) {
-                    indices.erase(it);
-                }
-                return;
-            }
-            notFound = false;
-        }
-        indices.push_back(
-            std::make_pair(std::forward<A>(x), std::forward<I>(ind)));
-        return;
+    inline size_t size() const { return dim; }
+    inline auto begin() { return inds; }
+    inline auto end() { return inds + dim; }
+    inline auto begin() const { return inds; }
+    inline auto end() const { return inds + dim; }
+    inline auto cbegin() const { return inds + dim; }
+    inline auto cend() const { return inds + dim; }
+    size_t rank() const {
+        size_t r = 0;
+        for (size_t i = 0; i < dim; ++i)
+            r += (inds[i] != 0);
+        return r;
     }
-    template <typename A, typename I> void subTerm(A &&x, I &&ind) {
-        auto it = begin();
-        auto ite = end();
-        auto indTyp = ind.getType();
-        bool notFound = true;
-        for (; it != ite; ++it) {
-            bool typeMisMatch = (it->second).getType() != indTyp;
-            if (typeMisMatch & notFound) {
-                continue;
-            } else if (typeMisMatch || (ind < (it->second))) {
-                indices.insert(it, std::make_pair(cnegate(std::forward<A>(x)),
-                                                  std::forward<I>(ind)));
-                return;
-            } else if (ind == (it->second)) {
-                (it->first) -= x;
-                if (isZero((it->first))) {
-                    indices.erase(it);
-                }
-                return;
-            }
-            notFound = false;
-        }
-        indices.push_back(
-            std::make_pair(cnegate(std::forward<A>(x)), std::forward<I>(ind)));
-        return;
+    // int64_t &operator[](size_t i) { return inds[i]; }
+    int64_t operator[](size_t i) const { return inds[i]; }
+    // llvm::MutableArrayRef<int64_t> indices() {
+    //     return llvm::MutableArrayRef{inds, dim};
+    // }
+    llvm::ArrayRef<int64_t> indices() const {
+        return llvm::ArrayRef{inds, dim};
     }
-
-    Stride &operator+=(Stride const &x) {
-        for (auto it = x.cbegin(); it != x.cend(); ++it) {
-            addTerm(std::get<0>(*it), std::get<1>(*it));
-        }
+    bool isLoopIndependent() const { return allZero(indices()); }
+    // MPoly &stride() { return strideAndOffset->first; }
+    // MPoly &offset() { return strideAndOffset->second; }
+    const MPoly &stride() const { return strideAndOffset->first; }
+    const MPoly &offset() const { return strideAndOffset->second; }
+    bool operator==(Stride x) {
+        return indices() == x.indices() && stride() == x.stride() &&
+               x.offset() == x.offset();
+    }
+};
+struct StrideIterator {
+    Stride x;
+    StrideIterator operator++() {
+        x.strideAndOffset++;
+        x.inds += x.dim;
         return *this;
     }
-    Stride &operator-=(Stride const &x) {
-        for (auto it = x.cbegin(); it != x.cend(); ++it) {
-            subTerm(std::get<0>(*it), std::get<1>(*it));
-        }
+    StrideIterator operator--() {
+        x.strideAndOffset--;
+        x.inds -= x.dim;
         return *this;
     }
-    Stride largerCapacityCopy(size_t i) const {
-        Stride s(stride);
-        s.indices.reserve(i + indices.size()); // reserve full size
-        for (auto &ind : indices) {
-            s.indices.push_back(ind); // copy initial batch
-        }
-        // for (size_t i = 1; i < 5; ++i) {
-        //     s.counts[i] = counts[i];
-        // }
-        return s;
+    bool operator==(StrideIterator y) {
+        return x.strideAndOffset == y.x.strideAndOffset;
     }
-
-    Stride operator+(Stride const &x) const {
-        Stride y = largerCapacityCopy(x.indices.size());
-        y += x;
-        return y;
-    }
-    Stride operator+(Stride &&x) const { return x += *this; }
-    Stride operator-(Stride const &x) const {
-        // don't increase capcity, in hopes of terms cancelling out.
-        // Stride y = largerCapacityCopy(x.indices.size());
-        Stride y = *this;
-        y -= x;
-        return y;
-    }
-    Stride &negBang() {
-        for (auto ind : indices) {
-            ind.first.negate();
-        }
-        return *this;
-    }
-    Stride neg() const {
-        Stride y = *this;
-        return y.negBang();
-    }
-    bool operator==(Stride const &x) const {
-        return (stride == x.stride) && (indices == x.indices);
-    }
-    bool operator!=(Stride const &x) const {
-        return (stride != x.stride) || (indices != x.indices);
-    }
-
-    bool isConstant() const {
-        size_t n0 = indices.size();
-        if (n0) {
-            return indices[n0 - 1].second.getType() == VarType::Constant;
-        } else {
-            return true;
-        }
-    }
-    // // takes advantage of sorting
-    // bool isAffine() const { return counts[2] == counts[4]; }
-
-    // std::pair<Polynomial,DivRemainder> tryDiv(Polynomial &a){
-    //	auto [s, v] = gcd(a.terms);
-
-    // }
-
-    // bool operator>=(Polynomial x){
-
-    //	return false;
-    // }
+    Stride operator*() { return x; }
 };
 
 std::ostream &operator<<(std::ostream &os, Stride const &axis) {
-    bool strideIsOne = isOne(axis.stride);
+    bool strideIsOne = isOne(axis.stride());
     if (!strideIsOne) {
-        os << axis.stride << " * (";
+        os << axis.stride() << " * ( ";
     }
     bool printPlus = false;
-    for (auto &indvar : axis) {
-        auto &[mlt, var] = indvar;
-        if (auto optc = mlt.getCompileTimeConstant()) {
-            int64_t c = optc.getValue();
+    for (size_t i = 0; i < axis.dim; ++i) {
+        int64_t c = axis[i];
+        if (c) {
             if (printPlus) {
                 if (c < 0) {
                     c *= -1;
@@ -243,25 +83,26 @@ std::ostream &operator<<(std::ostream &os, Stride const &axis) {
                 }
             }
             if (c == 1) {
-                os << "{ " << var << " }";
+                os << "i_" << i << " ";
             } else {
-                os << c << "* { " << var << " }";
+                os << c << " * i_" << i << " ";
             }
-        } else {
-            if (printPlus) {
-                os << " + ";
-            }
-            os << mlt << "* { " << var << " }";
+	    printPlus = true;
         }
-        printPlus = true;
+    }
+    if (!isZero(axis.offset())) {
+        if (printPlus) {
+            os << " + ";
+        }
+        os << axis.offset();
     }
     if (!strideIsOne) {
-        os << ")";
+        os << " )";
     }
     return os;
 }
 
-static constexpr unsigned ArrayRefPreAllocSize = 2;
+// static constexpr unsigned ArrayRefPreAllocSize = 2;
 
 // M*N*i + M*j + i
 // [M*N + 1]*i, [M]*j
@@ -280,7 +121,8 @@ static constexpr unsigned ArrayRefPreAllocSize = 2;
 // struct ArrayReferenceFlat {
 //     size_t arrayID;
 //     std::shared_ptr<AffineLoopNest> loop;
-//     llvm::SmallVector<std::pair<MPoly, VarID>, ArrayRefPreAllocSize> inds;
+//     llvm::SmallVector<std::pair<MPoly, VarID>, ArrayRefPreAllocSize>
+//     inds;
 // };
 
 // `foo` and `bar` can share the same `AffineLoopNest` (of depth 3), but
@@ -296,88 +138,96 @@ static constexpr unsigned ArrayRefPreAllocSize = 2;
 // end
 struct ArrayReference {
     size_t arrayID;
-    std::shared_ptr<AffineLoopNest> loop;
-    llvm::SmallVector<Stride, ArrayRefPreAllocSize> axes;
-    // llvm::SmallVector<uint32_t, ArrayRefPreAllocSize> indToStrideMap;
-    size_t dim() const { return axes.size(); }
+    llvm::IntrusiveRefCntPtr<AffineLoopNest> loop;
+    // std::shared_ptr<AffineLoopNest> loop;
+    llvm::SmallVector<std::pair<MPoly, MPoly>> stridesOffsets;
+    llvm::SmallVector<int64_t> indices;
+
+    size_t dim() const { return stridesOffsets.size(); }
     size_t getNumLoops() const { return loop->getNumLoops(); }
-    ArrayReference(size_t arrayID, std::shared_ptr<AffineLoopNest> loop)
+    PtrMatrix<int64_t> indexMatrix() {
+        const size_t numLoops = getNumLoops();
+        return {
+            .mem = indices.data(), .M = dim(), .N = numLoops, .X = numLoops};
+    }
+    PtrMatrix<const int64_t> indexMatrix() const {
+        const size_t numLoops = getNumLoops();
+        return {
+            .mem = indices.data(), .M = dim(), .N = numLoops, .X = numLoops};
+    }
+
+    ArrayReference(size_t arrayID,
+                   llvm::IntrusiveRefCntPtr<AffineLoopNest> loop)
         : arrayID(arrayID), loop(loop){};
-    ArrayReference(size_t arrayID, std::shared_ptr<AffineLoopNest> loop,
-                   llvm::SmallVector<Stride, ArrayRefPreAllocSize> axes)
-        : arrayID(arrayID), loop(loop), axes(axes) {
-        // TODO: fill indToStrideMap;
+    ArrayReference(size_t arrayID, AffineLoopNest &loop)
+        : arrayID(arrayID),
+          loop(llvm::IntrusiveRefCntPtr<AffineLoopNest>(&loop)){};
+
+    void resize(size_t d) {
+        stridesOffsets.resize(d);
+        indices.resize(d * getNumLoops());
     }
-    void pushAffineAxis(const Stride &stride, llvm::ArrayRef<int64_t> s,
-                        size_t j = 0) {
-        axes.emplace_back(stride.stride);
-        llvm::SmallVector<std::pair<MPoly, VarID>, 1> &inds =
-            axes.back().indices;
-        for (IDType i = 0; i < s.size(); ++i) {
-            if (int64_t c = s[i]) {
-                inds.emplace_back(c,
-                                  VarID(i + j, VarType::LoopInductionVariable));
-                assert(inds.back().first.getCompileTimeConstant().getValue() ==
-                       c);
-            }
-        }
-        for (auto &i : stride) {
-            if ((i.second.getType() != VarType::LoopInductionVariable) ||
-                (i.second.getID() < j)) {
-                inds.push_back(i);
-            }
-        }
+    ArrayReference(size_t arrayID,
+                   llvm::IntrusiveRefCntPtr<AffineLoopNest> loop, size_t dim)
+        : arrayID(arrayID), loop(loop) {
+        resize(dim);
+    };
+    ArrayReference(size_t arrayID, AffineLoopNest &loop, size_t dim)
+        : arrayID(arrayID),
+          loop(llvm::IntrusiveRefCntPtr<AffineLoopNest>(&loop)) {
+        resize(dim);
+    };
+    // StrideIterator begin() {
+    //     return StrideIterator{
+    //         Stride{stridesOffsets.data(), indices.data(), getNumLoops()}};
+    // }
+    // StrideIterator end() {
+    //     return StrideIterator{Stride{stridesOffsets.end(),
+    //                                  indices.data() + indices.size(),
+    //                                  getNumLoops()}};
+    // }
+    StrideIterator begin() const {
+        return {stridesOffsets.data(), indices.data(), getNumLoops()};
     }
-    auto begin() { return axes.begin(); }
-    auto end() { return axes.end(); }
-    auto begin() const { return axes.begin(); }
-    auto end() const { return axes.end(); }
-    bool allConstantStrides() const {
-        for (auto &axis : axes) {
-            if (!axis.allConstantIndices()) {
+    StrideIterator end() const {
+        return {stridesOffsets.end(), indices.data() + indices.size(),
+                getNumLoops()};
+    }
+    Stride operator[](size_t i) const {
+        size_t numLoops = getNumLoops();
+        return {stridesOffsets.data() + i, indices.data() + numLoops * i,
+                numLoops};
+    }
+    bool isLoopIndependent() const { return allZero(indices); }
+    bool allConstantIndices() const {
+        for (auto &so : stridesOffsets) {
+            if (!so.first.isCompileTimeConstant())
                 return false;
-            }
         }
         return true;
     }
+    // Assumes stridesOffsets are sorted
     bool stridesMatch(const ArrayReference &x) const {
         if (dim() != x.dim()) {
             return false;
         }
         for (size_t i = 0; i < dim(); ++i) {
-            const Stride &ys = axes[i];
-            const Stride &xs = x.axes[i];
-            if (ys.stride != xs.stride) {
+            if (stridesOffsets[i].first != x.stridesOffsets[i].first)
                 return false;
-            }
-        }
-        return true;
-    }
-    bool stridesMatchAllConstant(const ArrayReference &x) const {
-        if (dim() != x.dim()) {
-            return false;
-        }
-        for (size_t i = 0; i < dim(); ++i) {
-            const Stride &ys = axes[i];
-            const Stride &xs = x.axes[i];
-            if (!((ys.stride == xs.stride) && xs.allConstantIndices() &&
-                  ys.allConstantIndices())) {
-                return false;
-            }
         }
         return true;
     }
     friend std::ostream &operator<<(std::ostream &os,
                                     ArrayReference const &ar) {
-        os << "ArrayReference " << ar.arrayID << " (dim = " << ar.axes.size()
+        os << "ArrayReference " << ar.arrayID << " (dim = " << ar.dim()
            << "):" << std::endl;
-        for (auto &ax : ar) {
+        for (auto ax : ar) {
             std::cout << ax << std::endl;
         }
         return os;
     }
     // use gcd to check if they're known to be independent
-    bool gcdKnownIndependent(const ArrayReference &x) const {
+    bool gcdKnownIndependent(const ArrayReference &) const {
         // TODO: handle this!
         // consider `x[2i]` vs `x[2i + 1]`, the former
         // will have a stride of `2`, and the latter of `x[2i+1]`
@@ -386,7 +236,8 @@ struct ArrayReference {
     }
 };
 
-// std::ostream &operator<<(std::ostream &os, ArrayReferenceFlat const &ar) {
+// std::ostream &operator<<(std::ostream &os, ArrayReferenceFlat const &ar)
+// {
 //     os << "ArrayReference " << ar.arrayID << ":" << std::endl;
 //     for (size_t i = 0; i < length(ar.inds); ++i) {
 //         auto [ind, src] = ar.inds[i];

--- a/include/DependencyPolyhedra.hpp
+++ b/include/DependencyPolyhedra.hpp
@@ -28,7 +28,7 @@ struct DependencePolyhedra : SymbolicEqPolyhedra {
         // fast path; most common case
         if (ar0.stridesMatchAllConstant(ar1)) {
             llvm::SmallVector<std::pair<int, int>, 4> dims;
-            size_t numDims = ar0.dim();
+            size_t numDims = ar0.arrayDim();
             dims.reserve(numDims);
             for (size_t i = 0; i < numDims; ++i) {
                 dims.emplace_back(i, i);

--- a/include/DependencyPolyhedra.hpp
+++ b/include/DependencyPolyhedra.hpp
@@ -12,7 +12,6 @@
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/Optional.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/IR/User.h>
 #include <utility>
 
 struct DependencePolyhedra : SymbolicEqPolyhedra {
@@ -400,36 +399,6 @@ struct DependencePolyhedra : SymbolicEqPolyhedra {
     }
 
 }; // namespace DependencePolyhedra
-// TODO:
-// refactor to use GraphTraits.h 
-// https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/ADT/GraphTraits.h
-struct MemoryAccess {
-    ArrayReference ref;
-    // unsigned ref; // index to ArrayReference
-    llvm::User *user;
-    // unsigned (instead of ptr) as we build up edges
-    // and I don't want to relocate pointers when resizing vector
-    Schedule schedule;
-    llvm::SmallVector<unsigned> edgesIn;
-    llvm::SmallVector<unsigned> edgesOut;
-    const bool isLoad;
-    MemoryAccess(ArrayReference ref, llvm::User *user, Schedule schedule,
-                 bool isLoad)
-        : ref(std::move(ref)), user(user), schedule(schedule),
-          edgesIn(llvm::SmallVector<unsigned>()),
-          edgesOut(llvm::SmallVector<unsigned>()), isLoad(isLoad){};
-
-    void addEdgeIn(unsigned i) { edgesIn.push_back(i); }
-    void addEdgeOut(unsigned i) { edgesOut.push_back(i); }
-    // size_t getNumLoops() const { return ref->getNumLoops(); }
-    // size_t getNumAxes() const { return ref->axes.size(); }
-    // std::shared_ptr<AffineLoopNest> loop() { return ref->loop; }
-    bool fusedThrough(MemoryAccess &x) {
-        // originally separate loops could be fused
-        // if (loop() != x.loop()){ return false; }
-        return schedule.fusedThrough(x.schedule);
-    }
-};
 
 struct Dependence {
     DependencePolyhedra depPoly;

--- a/include/LoopBlock.hpp
+++ b/include/LoopBlock.hpp
@@ -293,7 +293,7 @@ struct LoopBlock {
             if (mai.isLoad)
                 continue;
             ArrayReference &refI = mai.ref;
-            size_t dimI = refI.dim();
+            size_t dimI = refI.arrayDim();
             auto &axesI = refI.axes;
             size_t multiInds = 0;
             size_t multiLoops = 0;
@@ -322,7 +322,7 @@ struct LoopBlock {
             size_t numLoops = refI.getNumLoops();
             // size_t numLoad = 0;
             size_t numStore = 1;
-            size_t numRow = refI.dim();
+            size_t numRow = refI.arrayDim();
             // we prioritize orthogonalizing stores
             // therefore, we sort the loads after
             llvm::SmallVector<unsigned, 16> orthInds;
@@ -335,7 +335,7 @@ struct LoopBlock {
                     continue;
                 ArrayReference &refJ = maj.ref;
                 numLoops = std::max(numLoops, refJ.getNumLoops());
-                numRow += refJ.dim();
+                numRow += refJ.arrayDim();
                 // numLoad += maj.isLoad;
                 numStore += (!maj.isLoad);
                 // TODO: maybe don't set so aggressive, e.g.

--- a/include/Loops.hpp
+++ b/include/Loops.hpp
@@ -8,13 +8,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/ADT/SmallVector.h>
 
 // A' * i <= b
 // l are the lower bounds
 // u are the upper bounds
 // extrema are the extremes, in orig order
-struct AffineLoopNest : SymbolicPolyhedra {
+struct AffineLoopNest : SymbolicPolyhedra,
+                        llvm::RefCountedBase<AffineLoopNest> {
     Permutation perm; // maps current to orig
     llvm::SmallVector<IntMatrix, 0> remainingA;
     llvm::SmallVector<llvm::SmallVector<MPoly, 8>, 0> remainingB;

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -331,6 +331,15 @@ template <typename T> struct StridedVector {
     T &operator[](size_t i) { return d[i * x]; }
     const T &operator[](size_t i) const { return d[i * x]; }
     size_t size() const { return N; }
+    bool operator==(StridedVector<T> x) const {
+        if (size() != x.size())
+            return false;
+        for (size_t i = 0; i < size(); ++i) {
+            if ((*this)[i] != x[i])
+                return false;
+        }
+        return true;
+    }
 };
 
 template <typename T, typename A> struct BaseMatrix {

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -375,14 +375,16 @@ template <typename T, typename A> struct BaseMatrix {
     size_t length() const { return numRow() * numCol(); }
 
     T &operator()(size_t i, size_t j) {
-// #ifndef NDEBUG
-// 	if ((i >= numRow()) || (j >= numCol())){
-//         std::cout << "Bounds Error! Accessed (" << numRow() << ", " << numCol() << ") array at index (" << i << ", " << j << ").\n" << 
-//             stacktrace::current() << std::endl;
+        // #ifndef NDEBUG
+        // 	if ((i >= numRow()) || (j >= numCol())){
+        //         std::cout << "Bounds Error! Accessed (" << numRow() << ", "
+        //         << numCol() << ") array at index (" << i << ", " << j <<
+        //         ").\n" <<
+        //             stacktrace::current() << std::endl;
         assert(i < numRow());
         assert(j < numCol());
-//     }
-// #endif
+        //     }
+        // #endif
         return getLinearElement(i * rowStride() + j * colStride());
     }
     const T &operator()(size_t i, size_t j) const {
@@ -455,7 +457,7 @@ template <typename T> struct PtrMatrix : BaseMatrix<T, PtrMatrix<T>> {
     const T *data() const { return mem; }
 
     operator PtrMatrix<const T>() const {
-        return {.mem = mem, .M = M, .N = M, .X = M};
+        return PtrMatrix<const T>{.mem = mem, .M = M, .N = N, .X = X};
     }
 };
 
@@ -490,7 +492,7 @@ struct Matrix<T, M, 0, S> : BaseMatrix<T, Matrix<T, M, 0, S>> {
     llvm::SmallVector<T, S> mem;
     size_t N, X;
 
-    Matrix(size_t n) : mem(llvm::SmallVector<T,S>(M * n)), N(n), X(n){};
+    Matrix(size_t n) : mem(llvm::SmallVector<T, S>(M * n)), N(n), X(n){};
 
     inline T &getLinearElement(size_t i) { return mem[i]; }
     inline const T &getLinearElement(size_t i) const { return mem[i]; }
@@ -513,7 +515,7 @@ struct Matrix<T, 0, N, S> : BaseMatrix<T, Matrix<T, 0, N, S>> {
     llvm::SmallVector<T, S> mem;
     size_t M;
 
-    Matrix(size_t m) : mem(llvm::SmallVector<T,S>(m * N)), M(m){};
+    Matrix(size_t m) : mem(llvm::SmallVector<T, S>(m * N)), M(m){};
 
     inline T &getLinearElement(size_t i) { return mem[i]; }
     inline const T &getLinearElement(size_t i) const { return mem[i]; }
@@ -556,8 +558,7 @@ struct SquarePtrMatrix : BaseMatrix<T, SquarePtrMatrix<T>> {
     // operator SquarePtrMatrix<const T>() const { return {.mem = mem, .M = M};
     // }
     explicit operator PtrMatrix<const T>() const {
-	return {.mem = mem, .M = M, .N = M, .X = M};
-        return PtrMatrix<const T>(mem, M);
+        return PtrMatrix<const T>{.mem = mem, .M = M, .N = M, .X = M};
     }
     operator SquarePtrMatrix<const T>() const {
         return SquarePtrMatrix<const T>(mem, M);
@@ -571,7 +572,8 @@ struct SquareMatrix : BaseMatrix<T, SquareMatrix<T, STORAGE>> {
     llvm::SmallVector<T, TOTALSTORAGE> mem;
     size_t M;
 
-    SquareMatrix(size_t m) : mem(llvm::SmallVector<T,TOTALSTORAGE>(m * m)), M(m){};
+    SquareMatrix(size_t m)
+        : mem(llvm::SmallVector<T, TOTALSTORAGE>(m * m)), M(m){};
 
     inline T &getLinearElement(size_t i) { return mem[i]; }
     inline const T &getLinearElement(size_t i) const { return mem[i]; }
@@ -610,10 +612,10 @@ struct SquareMatrix : BaseMatrix<T, SquareMatrix<T, STORAGE>> {
         return A;
     }
     operator PtrMatrix<T>() {
-        return {.mem = mem.data(), .M = M, .N = M, .X = M};
+        return PtrMatrix<T>{.mem = mem.data(), .M = M, .N = M, .X = M};
     }
     operator PtrMatrix<const T>() const {
-        return {.mem = mem.data(), .M = M, .N = M, .X = M};
+        return PtrMatrix<const T>{.mem = mem.data(), .M = M, .N = M, .X = M};
     }
     operator SquarePtrMatrix<T>() {
         return SquarePtrMatrix(mem.data(), size_t(M));
@@ -627,7 +629,7 @@ struct Matrix<T, 0, 0, S> : BaseMatrix<T, Matrix<T, 0, 0, S>> {
     size_t M, N, X;
 
     Matrix(size_t m, size_t n)
-        : mem(llvm::SmallVector<T,S>(m * n)), M(m), N(n), X(n){};
+        : mem(llvm::SmallVector<T, S>(m * n)), M(m), N(n), X(n){};
 
     Matrix() : M(0), N(0), X(0){};
     Matrix(SquareMatrix<T> &&A)
@@ -636,10 +638,10 @@ struct Matrix<T, 0, 0, S> : BaseMatrix<T, Matrix<T, 0, 0, S>> {
         : mem(A.mem.begin(), A.mem.end()), M(A.M), N(A.M), X(A.M){};
 
     operator PtrMatrix<T>() {
-        return {.mem = mem.data(), .M = M, .N = N, .X = X};
+        return PtrMatrix<T>{.mem = mem.data(), .M = M, .N = N, .X = X};
     }
     operator PtrMatrix<const T>() const {
-        return {.mem = mem.data(), .M = M, .N = N, .X = X};
+        return PtrMatrix<const T>{.mem = mem.data(), .M = M, .N = N, .X = X};
     }
 
     inline T &getLinearElement(size_t i) { return mem[i]; }
@@ -666,10 +668,10 @@ struct Matrix<T, 0, 0, S> : BaseMatrix<T, Matrix<T, 0, 0, S>> {
         return A;
     }
     static Matrix<T, 0, 0, S> identity(size_t MM) {
-        Matrix<T, 0, 0, S> A(MM,MM);
-	for (size_t i = 0; i < MM; ++i){
-	    A(i,i) = 1;
-	}
+        Matrix<T, 0, 0, S> A(MM, MM);
+        for (size_t i = 0; i < MM; ++i) {
+            A(i, i) = 1;
+        }
         return A;
     }
     void clear() {
@@ -745,6 +747,15 @@ struct Matrix<T, 0, 0, S> : BaseMatrix<T, Matrix<T, 0, 0, S>> {
         assert(MM <= M);
         M = MM;
     }
+    Matrix<T, 0, 0, S> transpose() const {
+        Matrix<T, 0, 0, S> A(Matrix<T, 0, 0, S>::Uninitialized(N, M));
+        for (size_t n = 0; n < N; ++n) {
+            for (size_t m = 0; m < M; ++m) {
+                A(n, m) = (*this)(m, n);
+            }
+        }
+        return A;
+    }
 };
 template <typename T> using DynamicMatrix = Matrix<T, 0, 0, 64>;
 typedef DynamicMatrix<int64_t> IntMatrix;
@@ -811,7 +822,7 @@ MULTIVERSION IntMatrix matmul(PtrMatrix<const int64_t> A,
     IntMatrix C(M, N);
     for (size_t m = 0; m < M; ++m) {
         for (size_t k = 0; k < K; ++k) {
-	    VECTORIZE
+            VECTORIZE
             for (size_t n = 0; n < N; ++n) {
                 C(m, n) += A(m, k) * B(k, n);
             }
@@ -828,7 +839,7 @@ MULTIVERSION IntMatrix matmulnt(PtrMatrix<const int64_t> A,
     IntMatrix C(M, N);
     for (size_t m = 0; m < M; ++m) {
         for (size_t k = 0; k < K; ++k) {
-	    VECTORIZE
+            VECTORIZE
             for (size_t n = 0; n < N; ++n) {
                 C(m, n) += A(m, k) * B(n, k);
             }
@@ -845,7 +856,7 @@ MULTIVERSION IntMatrix matmultn(PtrMatrix<const int64_t> A,
     IntMatrix C(M, N);
     for (size_t m = 0; m < M; ++m) {
         for (size_t k = 0; k < K; ++k) {
-	    VECTORIZE
+            VECTORIZE
             for (size_t n = 0; n < N; ++n) {
                 C(m, n) += A(k, m) * B(k, n);
             }
@@ -862,7 +873,7 @@ MULTIVERSION IntMatrix matmultt(PtrMatrix<const int64_t> A,
     IntMatrix C(M, N);
     for (size_t m = 0; m < M; ++m) {
         for (size_t k = 0; k < K; ++k) {
-	    VECTORIZE
+            VECTORIZE
             for (size_t n = 0; n < N; ++n) {
                 C(m, n) += A(k, m) * B(n, k);
             }

--- a/include/Schedule.hpp
+++ b/include/Schedule.hpp
@@ -3,6 +3,7 @@
 #include "./ArrayReference.hpp"
 #include "./Graphs.hpp"
 #include "./Math.hpp"
+#include "llvm/IR/User.h"
 #include <cstdint>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
@@ -59,3 +60,35 @@ struct Schedule {
         return fusedThrough(y, std::min(numLoops, y.numLoops));
     }
 };
+
+// TODO:
+// refactor to use GraphTraits.h 
+// https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/ADT/GraphTraits.h
+struct MemoryAccess {
+    ArrayReference ref;
+    // unsigned ref; // index to ArrayReference
+    llvm::User *user;
+    // unsigned (instead of ptr) as we build up edges
+    // and I don't want to relocate pointers when resizing vector
+    Schedule schedule;
+    llvm::SmallVector<unsigned> edgesIn;
+    llvm::SmallVector<unsigned> edgesOut;
+    const bool isLoad;
+    MemoryAccess(ArrayReference ref, llvm::User *user, Schedule schedule,
+                 bool isLoad)
+        : ref(std::move(ref)), user(user), schedule(schedule),
+          edgesIn(llvm::SmallVector<unsigned>()),
+          edgesOut(llvm::SmallVector<unsigned>()), isLoad(isLoad){};
+
+    void addEdgeIn(unsigned i) { edgesIn.push_back(i); }
+    void addEdgeOut(unsigned i) { edgesOut.push_back(i); }
+    // size_t getNumLoops() const { return ref->getNumLoops(); }
+    // size_t getNumAxes() const { return ref->axes.size(); }
+    // std::shared_ptr<AffineLoopNest> loop() { return ref->loop; }
+    bool fusedThrough(MemoryAccess &x) {
+        // originally separate loops could be fused
+        // if (loop() != x.loop()){ return false; }
+        return schedule.fusedThrough(x.schedule);
+    }
+};
+

--- a/test/orthogonalize_test.cpp
+++ b/test/orthogonalize_test.cpp
@@ -70,9 +70,9 @@ TEST(OrthogonalizeTest, BasicAssertions) {
     {
         PtrMatrix<int64_t> IndMat = War.indexMatrix();
         IndMat(0, 0) = 1; // m
-        IndMat(0, 2) = 1; // i
+        IndMat(2, 0) = 1; // i
         IndMat(1, 1) = 1; // n
-        IndMat(1, 3) = 1; // j
+        IndMat(3, 1) = 1; // j
         War.stridesOffsets[0] = std::make_pair(One, Zero);
         War.stridesOffsets[1] = std::make_pair(I + M - One, Zero);
     }
@@ -82,8 +82,8 @@ TEST(OrthogonalizeTest, BasicAssertions) {
     ArrayReference Bar{1, alnp, 2};
     {
         PtrMatrix<int64_t> IndMat = Bar.indexMatrix();
-        IndMat(0, 2) = 1; // i
-        IndMat(1, 3) = 1; // j
+        IndMat(2, 0) = 1; // i
+        IndMat(3, 1) = 1; // j
         Bar.stridesOffsets[0] = std::make_pair(One, Zero);
         Bar.stridesOffsets[1] = std::make_pair(I, Zero);
     }
@@ -223,9 +223,9 @@ TEST(BadMul, BasicAssertions) {
     ArrayReference War(0, alnp, 2); //, axes, indTo
     {
         PtrMatrix<int64_t> IndMat = War.indexMatrix();
-        IndMat(0, jId) = 1;  // j
-        IndMat(1, iId) = 1;  // i
-        IndMat(1, lId) = -1; // l
+        IndMat(jId, 0) = 1;  // j
+        IndMat(iId, 1) = 1;  // i
+        IndMat(lId, 1) = -1; // l
         War.stridesOffsets[0] = std::make_pair(One, Zero);
         War.stridesOffsets[1] = std::make_pair(M, Zero);
     }
@@ -235,9 +235,9 @@ TEST(BadMul, BasicAssertions) {
     ArrayReference Bar(1, alnp, 2); //, axes, indTo
     {
         PtrMatrix<int64_t> IndMat = Bar.indexMatrix();
-        IndMat(0, jId) = 1;  // j
-        IndMat(1, lId) = 1;  // l
-        IndMat(1, jId) = -1; // j
+        IndMat(jId, 0) = 1;  // j
+        IndMat(lId, 1) = 1;  // l
+        IndMat(jId, 1) = -1; // j
         Bar.stridesOffsets[0] = std::make_pair(One, Zero);
         Bar.stridesOffsets[1] = std::make_pair(M, Zero);
     }
@@ -247,10 +247,10 @@ TEST(BadMul, BasicAssertions) {
     ArrayReference Car(2, alnp, 2); //, axes, indTo
     {
         PtrMatrix<int64_t> IndMat = Car.indexMatrix();
-        IndMat(0, lId) = 1;  // l
-        IndMat(0, jId) = -1; // j
-        IndMat(1, iId) = 1;  // i
-        IndMat(1, lId) = -1; // l
+        IndMat(lId, 0) = 1;  // l
+        IndMat(jId, 0) = -1; // j
+        IndMat(iId, 1) = 1;  // i
+        IndMat(lId, 1) = -1; // l
         Car.stridesOffsets[0] = std::make_pair(One, Zero);
         Car.stridesOffsets[1] = std::make_pair(O, Zero);
     }


### PR DESCRIPTION
So far I've only changed the array ref representation, so that we can call `nullSpace` directly.

if we have
```c++
ArrayReference ar;
auto A = ar.indexMatrix();
```
and let `i` be a vector representing loop indices, then `A*i` defines the indices of the array.
For example
```julia
A = [1 -1
    -1  0
     0  1 ]
```
corresponds to indexing some array `B` like...
```julia
for i = I, j = J, k = K
    B[i - j, k]
end
```
and then `nullSpace(A)` gives a time hyperplane, indicating repeated accesses of the same memory addresses.

We need to apply additional constraints on our schedules so that repeat accesses are in the same order, e.g. if we're repeatedly loading and storing in a loop, we need to ensure that loads follow stores and stores follow loads in the correct order.

The goal of this PR is to implement that.