### PR TITLE
add orthogonalize function to Gram-Schmidt integer matrices

### DIFF
--- a/benchmark/constraint_pruning_benchmark.cpp
+++ b/benchmark/constraint_pruning_benchmark.cpp
@@ -1,6 +1,7 @@
 #include "../include/AbstractEqualityPolyhedra.hpp"
 #include "../include/NormalForm.hpp"
 #include "../include/Polyhedra.hpp"
+#include "Orthogonalize.hpp"
 #include <benchmark/benchmark.h>
 #include <cstddef>
 #include <cstdint>
@@ -93,7 +94,8 @@ static void BM_NullSpace(benchmark::State &state) {
     B(5, 2) = -9;
 
     // fourth row is 0
-    // std::cout << "B=\n" << B << "\nnullSpace(B) =\n" << NormalForm::nullSpace(B) << std::endl;
+    // std::cout << "B=\n" << B << "\nnullSpace(B) =\n" <<
+    // NormalForm::nullSpace(B) << std::endl;
     for (auto _ : state) {
         NormalForm::nullSpace(B);
     }
@@ -133,5 +135,63 @@ static void BM_NullSpace2000(benchmark::State &state) {
 }
 // Register the function as a benchmark
 BENCHMARK(BM_NullSpace2000);
+
+static void BM_Orthogonalize(benchmark::State &state) {
+    IntMatrix A(7, 7);
+    IntMatrix B;
+    A(1, 1) = -2;
+    A(1, 2) = 2;
+    A(1, 3) = 0;
+    A(1, 4) = 1;
+    A(1, 5) = 1;
+    A(1, 6) = 1;
+    A(1, 7) = 2;
+    A(2, 1) = 3;
+    A(2, 2) = -3;
+    A(2, 3) = 2;
+    A(2, 4) = 3;
+    A(2, 5) = 2;
+    A(2, 6) = 3;
+    A(2, 7) = 2;
+    A(3, 1) = -3;
+    A(3, 2) = 0;
+    A(3, 3) = 2;
+    A(3, 4) = 3;
+    A(3, 5) = -2;
+    A(3, 6) = 0;
+    A(3, 7) = 1;
+    A(4, 1) = 2;
+    A(4, 2) = 1;
+    A(4, 3) = 0;
+    A(4, 4) = -1;
+    A(4, 5) = 3;
+    A(4, 6) = -1;
+    A(4, 7) = 1;
+    A(5, 1) = 1;
+    A(5, 2) = -3;
+    A(5, 3) = -3;
+    A(5, 4) = -2;
+    A(5, 5) = 2;
+    A(5, 6) = -2;
+    A(5, 7) = 2;
+    A(6, 1) = 0;
+    A(6, 2) = 0;
+    A(6, 3) = 1;
+    A(6, 4) = 2;
+    A(6, 5) = -3;
+    A(6, 6) = -2;
+    A(6, 7) = -2;
+    A(7, 1) = 0;
+    A(7, 2) = -3;
+    A(7, 3) = -2;
+    A(7, 4) = -1;
+    A(7, 5) = 1;
+    A(7, 6) = 0;
+    A(7, 7) = 1;
+    for (auto _ : state) {
+        B = orthogonalize(A);
+    }
+}
+BENCHMARK(BM_Orthogonalize);
 
 BENCHMARK_MAIN();

--- a/include/AbstractEqualityPolyhedra.hpp
+++ b/include/AbstractEqualityPolyhedra.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "./Polyhedra.hpp"
+#include "Constraints.hpp"
 
 template <class P, typename T>
 struct AbstractEqualityPolyhedra : public AbstractPolyhedra<P, T> {
@@ -41,7 +42,8 @@ struct AbstractEqualityPolyhedra : public AbstractPolyhedra<P, T> {
     }
     void dropEmptyConstraints() {
         ::dropEmptyConstraints(A, b);
-        ::dropEmptyConstraints(E, q);
+        // ::dropEmptyConstraints(E, q);
+        divByGCDDropZeros(E, q);
     }
     void removeExtraThenZeroExtraVariables(size_t numNotRemove,
                                            size_t numVarKeep) {

--- a/include/ILPConstraintElimination.hpp
+++ b/include/ILPConstraintElimination.hpp
@@ -252,7 +252,7 @@ void fourierMotzkin(IntMatrix auto &Anew, llvm::SmallVectorImpl<int64_t> &bnew,
                 if (k == j)
                     continue;
                 if (int64_t Eik = E(i, k)) {
-                    int64_t g = std::gcd(Eij, Eik);
+                    int64_t g = gcd(Eij, Eik);
                     int64_t Ejg = Eij / g;
                     int64_t Ekg = Eik / g;
                     for (size_t v = 0; v < numRow; ++v) {

--- a/include/LinearDiophantine.hpp
+++ b/include/LinearDiophantine.hpp
@@ -68,7 +68,7 @@ llvm::Optional<Tuple> linearDiophantine(int64_t d, Tuple a) {
             return {};
         }
     }
-    int64_t q = std::gcd(a0, a1);
+    int64_t q = gcd(a0, a1);
     // d == q*((a/q)*x + (b/q)*y) + ... == q*w + ...
     // solve the rest
     auto dio_dqc =

--- a/include/Orthogonalize.hpp
+++ b/include/Orthogonalize.hpp
@@ -4,7 +4,39 @@
 #include "./Math.hpp"
 #include "./NormalForm.hpp"
 #include "./Symbolics.hpp"
+#include <cstdint>
 #include <llvm/ADT/SmallVector.h>
+
+IntMatrix orthogonalize(IntMatrix A) {
+    if ((A.numCol() < 2) || (A.numRow() == 0))
+        return A;
+    normalizeByGCD(A.getRow(0));
+    if (A.numRow() == 1)
+        return A;
+    llvm::SmallVector<Rational, 8> buff;
+    buff.resize_for_overwrite(A.numCol());
+    for (size_t i = 1; i < A.numRow(); ++i) {
+        for (size_t j = 0; j < A.numCol(); ++j)
+            buff[j] = A(i, j);
+        for (size_t j = 0; j < i; ++j) {
+            int64_t n = 0;
+            int64_t d = 0;
+            for (size_t k = 0; k < A.numCol(); ++k) {
+                n += A(i, k) * A(j, k);
+                d += A(j, k) * A(j, k);
+            }
+            for (size_t k = 0; k < A.numCol(); ++k) {
+                buff[k] -= Rational::create(A(j, k) * n, d);
+            }
+        }
+        int64_t lm = 1;
+        for (size_t k = 0; k < A.numCol(); ++k)
+            lm = lcm(lm, buff[k].denominator);
+        for (size_t k = 0; k < A.numCol(); ++k)
+            A(i, k) = (lm * buff[k].numerator) / buff[k].denominator;
+    }
+    return A;
+}
 
 llvm::Optional<llvm::SmallVector<ArrayReference, 0>>
 orthogonalize(llvm::SmallVectorImpl<ArrayReference *> const &ai) {

--- a/include/Orthogonalize.hpp
+++ b/include/Orthogonalize.hpp
@@ -26,16 +26,25 @@ IntMatrix orthogonalize(IntMatrix A) {
                 d += A(j, k) * A(j, k);
             }
             for (size_t k = 0; k < A.numCol(); ++k) {
-                buff[k] -= Rational::create(A(j, k) * n, d);
+                buff[k] -= Rational::createPositiveDenominator(A(j, k) * n, d);
             }
         }
         int64_t lm = 1;
         for (size_t k = 0; k < A.numCol(); ++k)
             lm = lcm(lm, buff[k].denominator);
         for (size_t k = 0; k < A.numCol(); ++k)
-            A(i, k) = (lm * buff[k].numerator) / buff[k].denominator;
+            A(i, k) = buff[k].numerator * (lm / buff[k].denominator);
     }
     return A;
+}
+
+IntMatrix orthogonalNullSpace(IntMatrix A) {
+    return orthogonalize(NormalForm::nullSpace(std::move(A)));
+    // IntMatrix NS{NormalForm::nullSpace(std::move(A))};
+    // std::cout << "Pre-Orth NS =\n" << NS << std::endl;
+    // IntMatrix ONS{orthogonalize(std::move(NS))};
+    // std::cout << "Post-Orth NS =\n" << ONS << std::endl;
+    // return ONS;
 }
 
 llvm::Optional<llvm::SmallVector<ArrayReference, 0>>

--- a/include/Symbolics.hpp
+++ b/include/Symbolics.hpp
@@ -699,14 +699,15 @@ template <size_t L = 15, size_t E = 7> struct PackedMonomial {
     template <typename T> bool lexGreater(const T &y) const {
         return lexGreater(y.exponent);
     }
-    //std::strong_ordering operator<=>(PackedMonomial const &y) const {
-    //    if (K == 1) {
-    //        return bits[0] <=> y.bits[0];
-    //    }
-    //    const uint64_t *xp = this->bits;
-    //    const uint64_t *yp = y.bits;
-    //    return std::lexicographical_compare_three_way(xp, xp + K, yp, yp + K);
-    //}
+    // std::strong_ordering operator<=>(PackedMonomial const &y) const {
+    //     if (K == 1) {
+    //         return bits[0] <=> y.bits[0];
+    //     }
+    //     const uint64_t *xp = this->bits;
+    //     const uint64_t *yp = y.bits;
+    //     return std::lexicographical_compare_three_way(xp, xp + K, yp, yp +
+    //     K);
+    // }
     friend bool isOne(PackedMonomial const &x) { return (x.degree() == 0); }
     friend bool isZero(PackedMonomial const &) { return false; }
 
@@ -1455,12 +1456,14 @@ template <typename C, IsMonomial M> struct Terms {
 
     Term<C, M> &leadingTerm() { return terms[0]; }
     Term<C, M> const &leadingTerm() const { return terms[0]; }
-    C &leadingCoefficient() { 
+    C &leadingCoefficient() {
         assert(terms.size());
-        return begin()->coefficient; }
-    const C &leadingCoefficient() const { 
+        return begin()->coefficient;
+    }
+    const C &leadingCoefficient() const {
         assert(terms.size());
-        return begin()->coefficient; }
+        return begin()->coefficient;
+    }
     void removeLeadingTerm() { terms.erase(terms.begin()); }
     // void takeLeadingTerm(Term<C,M> &x) {
     //     addTerm(std::move(x.leadingTerm()));
@@ -1606,10 +1609,10 @@ Terms<int64_t, Uninomial> static operator-(Uninomial x, Uninomial y) {
         return Terms<int64_t, Uninomial>();
     } else if (x.lexGreater(y)) {
         return Terms<int64_t, Uninomial>(Term<int64_t, Uninomial>{1, x},
-                                          Term<int64_t, Uninomial>{-1, y});
+                                         Term<int64_t, Uninomial>{-1, y});
     } else {
         return Terms<int64_t, Uninomial>(Term<int64_t, Uninomial>{-1, y},
-                                          Term<int64_t, Uninomial>{1, x});
+                                         Term<int64_t, Uninomial>{1, x});
     }
 }
 template <IsMonomial M> static auto operator-(M const &x, M const &y) {
@@ -2568,11 +2571,13 @@ static Multivariate<C, M> operator*(Multivariate<C, M> &&c, int64_t x) {
 }
 
 template <IsMonomial M>
-static Multivariate<int64_t, M> operator*(int64_t x, Multivariate<int64_t, M> &&c) {
+static Multivariate<int64_t, M> operator*(int64_t x,
+                                          Multivariate<int64_t, M> &&c) {
     return std::move(c *= x);
 }
 template <IsMonomial M>
-static Multivariate<int64_t, M> operator*(Multivariate<int64_t, M> &&c, int64_t x) {
+static Multivariate<int64_t, M> operator*(Multivariate<int64_t, M> &&c,
+                                          int64_t x) {
     return std::move(c *= x);
 }
 
@@ -2937,6 +2942,7 @@ static Term<C, M> gcd(Term<C, M> const &x, Term<C, M> const &y) {
     C gr = gcd(x.coefficient, y.coefficient);
     return Term<C, M>(std::move(gr), std::move(g));
 }
+inline int64_t gcd(int64_t x, int64_t y) { return ::gcd(x, y); }
 template <typename C, IsMonomial M>
 static Term<C, M> gcd(Term<C, M> const &x, Term<C, M> const &y) {
     C gr = gcd(x.coefficient, y.coefficient);
@@ -3298,7 +3304,6 @@ typedef Polynomial::Multivariate<int64_t, Polynomial::Monomial> MPoly;
 //
 // [ 0 ], k1 + 1;
 //
-
 
 template <> struct llvm::DenseMapInfo<Polynomial::Monomial, void> {
     static inline Polynomial::Monomial getEmptyKey() {

--- a/include/Unimodularization.hpp
+++ b/include/Unimodularization.hpp
@@ -81,21 +81,21 @@ unimodularize1x3(int64_t a, int64_t b, int64_t c) {
     // we need
     // 1 == gcd(b - a*y, c - a*z)
     // int64_t args[3];
-    if (std::gcd(b, c) == 1) {
+    if (gcd(b, c) == 1) {
         auto t1 = std::make_tuple(int64_t(1), int64_t(0), int64_t(0));
         auto t2 = unimodularize2x3(a, b, c, 1, 0, 0);
         if (t2.hasValue()) {
             return std::make_pair(t1, t2.getValue());
         }
     }
-    if (std::gcd(a, c) == 1) {
+    if (gcd(a, c) == 1) {
         auto t1 = std::make_tuple(int64_t(0), int64_t(1), int64_t(0));
         auto t2 = unimodularize2x3(a, b, c, 0, 1, 0);
         if (t2.hasValue()) {
             return std::make_pair(t1, t2.getValue());
         }
     }
-    if (std::gcd(a, b) == 1) {
+    if (gcd(a, b) == 1) {
         auto t1 = std::make_tuple(int64_t(0), int64_t(0), int64_t(1));
         auto t2 = unimodularize2x3(a, b, c, 0, 0, 1);
         if (t2.hasValue()) {

--- a/test/orthogonalize_test.cpp
+++ b/test/orthogonalize_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
+#include <random>
 
 TEST(OrthogonalizeTest, BasicAssertions) {
     auto M = Polynomial::Monomial(Polynomial::ID{1});
@@ -283,5 +284,32 @@ TEST(BadMul, BasicAssertions) {
     std::cout << "New ArrayReferences:\n";
     for (auto &ar : newArrayRefs) {
         std::cout << ar << std::endl << std::endl;
+    }
+}
+
+TEST(OrthogonalizeMatricesTest, BasicAssertions) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> distrib(-3, 3);
+
+    const size_t M = 7;
+    const size_t N = 7;
+    IntMatrix A(M, N);
+    IntMatrix B(N, N);
+    const size_t iters = 1000;
+    for (size_t i = 0; i < iters; ++i){
+	for (auto &&a : A)
+	    a = distrib(gen);
+	// std::cout << "Random A =\n" << A << std::endl;
+	A = orthogonalize(std::move(A));
+	// std::cout << "Orthogonal A =\n" << A << std::endl;
+	// note, A'A is not diagonal
+	// but AA' is
+	matmulnt(B, A, A);
+	// std::cout << "A'A =\n" << B << std::endl;
+	for (size_t m = 0; m < M; ++m)
+	    for (size_t n = 0; n < N; ++n)
+		if (m != n)
+		    EXPECT_EQ(B(m,n), 0);
     }
 }


### PR DESCRIPTION
- [x] Add orthogonal null space function
- [x] use orthogonal null space for computing size of time steps
- [x] use these time steps for time dependency constraints
- [x] add tests and benchmarks for `orthogonalize`