### PR TITLE
Add SparseMatrix

### DIFF
--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -1,10 +1,63 @@
+#include "../include/Math.hpp"
+#include <cstdint>
 #include <gtest/gtest.h>
 
 // Demonstrate some basic assertions.
-TEST(HelloTest, BasicAssertions)
-{
-  // Expect two strings not to be equal.
-  EXPECT_STRNE("hello", "world");
-  // Expect equality.
-  EXPECT_EQ(7 * 6, 42);
+TEST(HelloTest, BasicAssertions) {
+    SparseMatrix<int64_t> Asparse(3, 4);
+    Asparse(0, 1) = 5;
+    Asparse(1, 3) = 3;
+    Asparse(2, 0) = -1;
+    Asparse(2, 1) = 4;
+    Asparse(2, 2) = -2;
+    IntMatrix A = Asparse;
+    //std::cout << "A.size() = ("<<A.numRow()<<", "<<A.numCol()<<")\n";
+    //std::cout << "\nAsparse = \n" << Asparse << std::endl;
+    //std::cout << "\nA = \n" << A << std::endl << std::endl;
+    for (size_t i = 0; i < 3; ++i)
+        for (size_t j = 0; j < 4; ++j)
+            EXPECT_TRUE(A(i, j) == Asparse(i, j));
+    // EXPECT_EQ(A(i, j), Asparse(i, j));
+    IntMatrix B(4, 5);
+    B(0, 0) = 3;
+    B(0, 1) = -1;
+    B(0, 2) = 0;
+    B(0, 3) = -5;
+    B(0, 4) = 1;
+    B(1, 0) = -4;
+    B(1, 1) = 5;
+    B(1, 2) = -1;
+    B(1, 3) = -1;
+    B(1, 4) = -1;
+    B(2, 0) = 1;
+    B(2, 1) = 2;
+    B(2, 2) = -5;
+    B(2, 3) = 2;
+    B(2, 4) = 3;
+    B(3, 0) = -2;
+    B(3, 1) = 1;
+    B(3, 2) = 2;
+    B(3, 3) = -3;
+    B(3, 4) = 5;
+    IntMatrix C{3,5};
+    C(0, 0) = -20;
+    C(0, 1) = 25;
+    C(0, 2) = -5;
+    C(0, 3) = -5;
+    C(0, 4) = -5;
+    C(1, 0) = -6;
+    C(1, 1) = 3;
+    C(1, 2) = 6;
+    C(1, 3) = -9;
+    C(1, 4) = 15;
+    C(2, 0) = -21;
+    C(2, 1) = 17;
+    C(2, 2) = 6;
+    C(2, 3) = -3;
+    C(2, 4) = -11;
+    IntMatrix C2{matmul(A, B)};
+    EXPECT_TRUE(C == C2);
+    EXPECT_TRUE(C == matmultn(A.transpose(), B));
+    EXPECT_TRUE(C == matmulnt(A, B.transpose()));
+    EXPECT_TRUE(C == matmultt(A.transpose(), B.transpose()));
 }


### PR DESCRIPTION
The idea is that this may be a more efficient representation of loop -> index mappings than a dense matrix.

Aside from being smaller, this sparse matrix allows for more easily checking the number of non-zeros in a row (i.e., checking which loops a particular axis depends on).

The sparsity is represented by a vector of masks, one mask per row.
The mask has 1 bits in positions where we have a non-zero.

I'm using 24 bits for the mask, with the remaining 8 bits indicating how many non-zeros we have in previous rows. I'm not sure whether that's more efficient than just summing `std::popcount` of the previous rows/how much more efficient.
It saves us from having to iterate over all rows on `get`, which is probably much more important than `insert`, which of course must be slow anyway.