### PR TITLE
No crtp matrix

### DIFF
--- a/include/Comparators.hpp
+++ b/include/Comparators.hpp
@@ -309,7 +309,7 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
         // We will have query of the form Ax = q;
         NormalForm::simplifySystemImpl(A, U);
         auto &H = A;
-        while ((R) && allZero(H.getRow(R - 1)))
+        while ((R) && allZero(H(R - 1, _)))
             --R;
         H.truncateRows(R);
         U.truncateRows(R);
@@ -492,7 +492,7 @@ static inline void moveEqualities(IntMatrix &A, IntMatrix &E,
                     break;
                 }
             }
-            if (isNeg && C.equalNegative(A.getRow(i), A.getRow(o))) {
+            if (isNeg && C.equalNegative(A(i, _), A(o, _))) {
                 size_t e = E.numRow();
                 E.resize(e + 1, numVar);
                 for (size_t v = 0; v < numVar; ++v)

--- a/include/Constraints.hpp
+++ b/include/Constraints.hpp
@@ -122,7 +122,7 @@ substituteEqualityImpl(IntMatrix &E, const size_t i) {
         }
     if (rowMinNonZero == numConstraints)
         return rowMinNonZero;
-    auto Es = E.getRow(rowMinNonZero);
+    auto Es = E(rowMinNonZero, _);
     int64_t Eis = Es[i];
     // we now subsitute the equality expression with the minimum number
     // of terms.
@@ -171,7 +171,7 @@ inline size_t substituteEqualityImpl(IntMatrix &A, IntMatrix &E,
     }
     if (rowMinNonZero == numConstraints)
         return rowMinNonZero;
-    auto Es = E.getRow(rowMinNonZero);
+    auto Es = E(rowMinNonZero, _);
     int64_t Eis = Es[i];
     int64_t s = 2 * (Eis > 0) - 1;
     // we now subsitute the equality expression with the minimum number
@@ -351,6 +351,6 @@ countNonZeroSign(PtrMatrix<int64_t> A, size_t i) {
 
 [[maybe_unused]] static void dropEmptyConstraints(IntMatrix &A) {
     for (size_t c = A.numRow(); c != 0;)
-        if (allZero(A.getRow(--c)))
+        if (allZero(A(--c, _)))
             eraseConstraint(A, c);
 }

--- a/include/EmptyArrays.hpp
+++ b/include/EmptyArrays.hpp
@@ -4,7 +4,9 @@
 #include <cstdint>
 #include <llvm/ADT/SmallVector.h>
 
-template <typename T> struct EmptyMatrix : BaseMatrix<T, EmptyMatrix<T>> {
+template <typename T> struct EmptyMatrix {
+    using eltype = T;
+    static constexpr bool canResize = false;
     static constexpr bool isMutable = false;
     static constexpr T getLinearElement(size_t) { return 0; }
     static constexpr T *begin() { return nullptr; }
@@ -17,8 +19,14 @@ template <typename T> struct EmptyMatrix : BaseMatrix<T, EmptyMatrix<T>> {
     static constexpr size_t getConstCol() { return 0; }
 
     static constexpr T *data() { return nullptr; }
-    inline T operator()(size_t, size_t) { return 0; }
+    constexpr T operator()(size_t, size_t) { return 0; }
+    static constexpr std::pair<size_t, size_t> size() {
+        return std::make_pair(0, 0);
+    }
+    static constexpr EmptyMatrix<T> view() { return EmptyMatrix<T>{}; }
 };
+
+static_assert(AbstractMatrix<EmptyMatrix<int64_t>>);
 
 template <typename T>
 constexpr EmptyMatrix<T> matmul(EmptyMatrix<T>, PtrMatrix<const T>) {
@@ -31,7 +39,7 @@ constexpr EmptyMatrix<T> matmul(PtrMatrix<const T>, EmptyMatrix<T>) {
 
 template <typename T, typename S>
 concept MaybeMatrix =
-    std::is_same_v<T, DynamicMatrix<S>> || std::is_same_v<T, EmptyMatrix<S>>;
+    std::is_same_v<T, Matrix<S>> || std::is_same_v<T, EmptyMatrix<S>>;
 
 template <typename T> struct EmptyVector {
     static constexpr size_t size() { return 0; };

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -668,8 +668,20 @@ struct Colon {
 constexpr size_t canonicalize(size_t e, size_t) { return e; }
 constexpr size_t canonicalize(Begin, size_t) { return 0; }
 constexpr size_t canonicalize(OffsetBegin b, size_t) { return b.offset; }
-constexpr size_t canonicalize(End, size_t M) { return M; }
-constexpr size_t canonicalize(OffsetEnd e, size_t M) { return M - e.offset; }
+constexpr size_t canonicalize(End, size_t M) { return M - 1; }
+constexpr size_t canonicalize(OffsetEnd e, size_t M) {
+    return M - 1 - e.offset;
+}
+
+constexpr size_t canonicalizeForRange(size_t e, size_t) { return e; }
+constexpr size_t canonicalizeForRange(Begin, size_t) { return 0; }
+constexpr size_t canonicalizeForRange(OffsetBegin b, size_t) {
+    return b.offset;
+}
+constexpr size_t canonicalizeForRange(End, size_t M) { return M; }
+constexpr size_t canonicalizeForRange(OffsetEnd e, size_t M) {
+    return M - e.offset;
+}
 
 // Union type
 template <typename T>
@@ -679,7 +691,8 @@ concept ScalarIndex =
 
 template <typename B, typename E>
 constexpr Range<size_t, size_t> canonicalizeRange(Range<B, E> r, size_t M) {
-    return Range<size_t, size_t>{canonicalize(r.b, M), canonicalize(r.e, M)};
+    return Range<size_t, size_t>{canonicalizeForRange(r.b, M),
+                                 canonicalizeForRange(r.e, M)};
 }
 constexpr Range<size_t, size_t> canonicalizeRange(Colon, size_t M) {
     return Range<size_t, size_t>{0, M};

--- a/include/NormalForm.hpp
+++ b/include/NormalForm.hpp
@@ -339,7 +339,7 @@ MULTIVERSION inline void reduceSubDiagonal(MutPtrMatrix<int64_t> A,
 // NormalForm version assumes sorted
 [[maybe_unused]] static size_t numNonZeroRows(PtrMatrix<int64_t> A) {
     size_t Mnew = A.numRow();
-    while (allZero(A.getRow(Mnew - 1)))
+    while (allZero(A(Mnew - 1, _)))
         --Mnew;
     return Mnew;
 }
@@ -382,7 +382,7 @@ MULTIVERSION [[maybe_unused]] static void simplifySystem(IntMatrix &A,
     simplifySystemImpl(A, B);
     size_t Mnew = A.numRow();
     bool need_trunc = false;
-    while (allZero(A.getRow(Mnew - 1))) {
+    while (allZero(A(Mnew - 1, _))) {
         --Mnew;
         need_trunc = true;
     }
@@ -628,7 +628,7 @@ MULTIVERSION [[maybe_unused]] static void solveSystem(IntMatrix &A) {
 //             reduceSubDiagonal(A, c, r++);
 //         }
 //     size_t R = M;
-//     while ((R > 0) && allZero(A.getRow(R - 1))) {
+//     while ((R > 0) && allZero(A(R - 1,_))) {
 //         --R;
 //     }
 //     A.truncateRows(R);
@@ -643,7 +643,7 @@ MULTIVERSION [[maybe_unused]] static void nullSpace11(IntMatrix &B,
     B.diag() = 1;
     solveSystem(A, B);
     size_t R = M;
-    while ((R > 0) && allZero(A.getRow(R - 1)))
+    while ((R > 0) && allZero(A(R - 1, _)))
         --R;
     // slice B[R:end, :]
     // if R == 0, no need to truncate or copy

--- a/include/Schedule.hpp
+++ b/include/Schedule.hpp
@@ -97,10 +97,10 @@ struct Schedule {
     }
     MutSquarePtrMatrix<int64_t> getPhi() {
         // return MutSquarePtrMatrix<int64_t>(data.data(), numLoops);
-        return MutSquarePtrMatrix<int64_t>{{}, data.data(), numLoops};
+        return MutSquarePtrMatrix<int64_t>{data.data(), numLoops};
     }
     SquarePtrMatrix<int64_t> getPhi() const {
-        return SquarePtrMatrix<int64_t>{{}, data.data(), numLoops};
+        return SquarePtrMatrix<int64_t>{data.data(), numLoops};
     }
     PtrVector<int64_t> getFusionOmega() const {
         return {.mem = data.data() + getNumLoopsSquared(),

--- a/include/Simplex.hpp
+++ b/include/Simplex.hpp
@@ -634,6 +634,13 @@ struct Simplex {
         // [ I A
         //   0 B ]
         // then drop the extra variables
+	SHOWLN(simplex.getConstraints().numRow());
+	SHOWLN(A.numRow());
+	SHOWLN(B.numRow());
+	SHOWLN(numCon);
+	SHOWLN(numVar);
+	SHOWLN(numSlack);
+	SHOWLN(numStrict);
         slackEqualityConstraints(
             simplex.getConstraints()(_(0, numCon), _(1, numVar + numSlack)),
             A(_(0, numSlack), _(1, numVar)), B(_(0, numStrict), _(1, numVar)));


### PR DESCRIPTION
Also, instead of setting phis independent, it uses the typemin sentinel to indicate arbitrary reordering is allowed.