### PR TITLE
AffineLoopNest now has a lower bound of 0

### DIFF
--- a/include/Loops.hpp
+++ b/include/Loops.hpp
@@ -222,37 +222,15 @@ simplifyMinMax(llvm::ScalarEvolution &SE, const llvm::SCEV *S) {
     return S;
 }
 
-// A' * i <= b
-// l are the lower bounds
-// u are the upper bounds
-// extrema are the extremes, in orig order
-struct AffineLoopNest : SymbolicPolyhedra { //,
-    // llvm::RefCountedBase<AffineLoopNest> {
-    // struct AffineLoopNest : Polyhedra<EmptyMatrix<int64_t>,
-    // SymbolicComparator> {
-    llvm::SmallVector<const llvm::SCEV *> symbols{};
-    // llvm::SmallVector<Polynomial::Monomial> symbols;
+// A * x >= 0
+struct UnboundedAffineLoopNest : SymbolicPolyhedra {
+    [[no_unique_address]] llvm::SmallVector<const llvm::SCEV *> symbols{};
     size_t getNumSymbols() const { return 1 + symbols.size(); }
     size_t getNumLoops() const { return A.numCol() - getNumSymbols(); }
 
-    size_t findIndex(const llvm::SCEV *v) {
+    size_t findIndex(const llvm::SCEV *v) const {
         return findSymbolicIndex(symbols, v);
     }
-    // static llvm::Optional<
-    //     std::tuple<const llvm::SCEV *, const llvm::Loop *, int64_t>>
-    // decomposeAffineConstStride(const llvm::SCEV *v) {
-    //     // ex->getStart() + ex->getLoop()*ex->getStepRecurrence(SE)
-    //     // ex->getOperand(0) + ex->getLoop()*ex->getOperand(1)
-    //     // we don't have SE here, so we're using the latter
-    //     // NOTE: if we start passing a ScalarEvolution, switch to former
-    //     if (const llvm::SCEVAddRecExpr *x =
-    //             llvm::dyn_cast<const llvm::SCEVAddRecExpr>(v))
-    //         if (x->isAffine())
-    //             if (auto c = getConstantInt(x->getOperand(1)))
-    //                 return std::make_tuple(x->getOperand(0), x->getLoop(),
-    //                 *c);
-    //     return {};
-    // }
     // add a symbol to row `r` of A
     // we try to break down value `v`, so that adding
     // N, N - 1, N - 3 only adds the variable `N`, and adds the constant offsets
@@ -334,9 +312,9 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
             minDepth = std::max(minDepth, recDepth);
         } else if (const llvm::SCEVMinMaxExpr *ex =
                        llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(v)) {
-	    auto S = simplifyMinMax(SE, ex);
-	    if (S != v)
-		return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
+            auto S = simplifyMinMax(SE, ex);
+            if (S != v)
+                return addSymbol(B, L, S, SE, l, u, mlt, minDepth);
             bool isMin = llvm::isa<llvm::SCEVSMinExpr>(ex) ||
                          llvm::isa<llvm::SCEVUMinExpr>(ex);
             llvm::errs() << "llvm::SCEVMinMaxExpr: " << *ex
@@ -358,9 +336,649 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
             } else if (addRecMatchesLoop(op1, L)) {
                 return addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
             } else {
-		// auto S = simplifyMinMax(SE, ex);
-		// if (S != v)
-		//     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
+                // auto S = simplifyMinMax(SE, ex);
+                // if (S != v)
+                //     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
+                llvm::errs() << "Failing on llvm::SCEVMinMaxExpr = " << *ex
+                             << "<<\n*L =" << *L << "\n";
+                SHOWLN(*op0);
+                SHOWLN(*op1);
+                // TODO: don't only consider final value
+                // this assumes the final value is the maximum, which is not
+                // necessarilly true
+                if (auto op0ar = llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
+                    // auto op0final = SE.getSCEVAtScope(
+                    //     op0ar, op0ar->getLoop()->getParentLoop());
+                    auto op0final = SE.getSCEVAtScope(op0ar, nullptr);
+                    SHOWLN(*op0final);
+                    auto op0FinalMinusOp1 = SE.getMinusSCEV(op0final, op1);
+                    SHOWLN(SE.isKnownNonNegative(op0FinalMinusOp1));
+                    SHOWLN(SE.isKnownNonPositive(op0FinalMinusOp1));
+                    auto op0init = op0ar->getOperand(0);
+                    auto op0InitMinusOp1 = SE.getMinusSCEV(op0init, op1);
+                    SHOWLN(SE.isKnownNonNegative(op0InitMinusOp1));
+                    SHOWLN(SE.isKnownNonPositive(op0InitMinusOp1));
+                    auto op0step = op0ar->getOperand(0);
+                    SHOWLN(SE.isKnownNonNegative(op0step));
+                    SHOWLN(SE.isKnownNonPositive(op0step));
+                }
+                if (auto op1ar = llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
+                    SHOWLN(*SE.getSCEVAtScope(
+                        op1ar, op1ar->getLoop()->getParentLoop()));
+                }
+                auto op0MinusOp1 = SE.getMinusSCEV(op0, op1);
+                SHOWLN(SE.isKnownNonNegative(op0MinusOp1));
+                SHOWLN(SE.isKnownNonPositive(op0MinusOp1));
+
+                if (auto b = L->getBounds(SE))
+                    llvm::errs()
+                        << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
+                        << "\nStep: " << *b->getStepValue()
+                        << "\nFinal: " << b->getFinalIVValue() << "\n";
+                assert(false);
+            }
+        } else if (const llvm::SCEVCastExpr *ex =
+                       llvm::dyn_cast<llvm::SCEVCastExpr>(v))
+            return addSymbol(B, L, ex->getOperand(0), SE, l, u, mlt, minDepth);
+        // } else if (const llvm::SCEVUDivExpr *ex = llvm::dyn_cast<const
+        // llvm::SCEVUDivExpr>(v)) {
+
+        // } else if (const llvm::SCEVUnknown *ex = llvm::dyn_cast<const
+        // llvm::SCEVUnknown>(v)) {
+        addSymbol(v, l, u, mlt);
+        return minDepth;
+    }
+    void addSymbol(const llvm::SCEV *v, size_t l, size_t u, int64_t mlt) {
+        assert(u > l);
+        // llvm::errs() << "Before adding sym A = " << A << "\n";
+        symbols.push_back(v);
+        A.resizeCols(A.numCol() + 1);
+        // A.insertZeroColumn(symbols.size());
+        for (size_t j = l; j < u; ++j)
+            A(j, symbols.size()) = mlt;
+        // llvm::errs() << "After adding sym A = " << A << "\n";
+    }
+    static bool addRecMatchesLoop(const llvm::SCEV *S, llvm::Loop *L) {
+        if (const llvm::SCEVAddRecExpr *x =
+                llvm::dyn_cast<const llvm::SCEVAddRecExpr>(S))
+            return x->getLoop() == L;
+        return false;
+    }
+    size_t addBackedgeTakenCount(IntMatrix &B, llvm::Loop *L,
+                                 const llvm::SCEV *BT,
+                                 llvm::ScalarEvolution &SE, size_t minDepth) {
+        size_t M = A.numRow();
+        A.resizeRows(M + 1);
+        B.resizeRows(M + 1);
+        llvm::errs() << "BT = " << *BT
+                     << "\naddBackedgeTakenCount pre addSym; M = " << M
+                     << "; A = " << A << "\n";
+        minDepth = addSymbol(B, L, BT, SE, M, M + 1, 1, minDepth);
+        llvm::errs() << "addBackedgeTakenCount post addSym; M = " << M
+                     << "; A = " << A << "\n";
+        assert(A.numRow() == B.numRow());
+        size_t depth = L->getLoopDepth();
+        for (size_t m = M; m < A.numRow(); ++m)
+            B(m, B.numCol() - depth) = -1; // indvar
+        // recurse, if possible to add an outer layer
+        if (llvm::Loop *P = L->getParentLoop()) {
+            if (areSymbolsLoopInvariant(P, SE)) {
+                // llvm::SmallVector<const llvm::SCEVPredicate *, 4> predicates;
+                // auto *BTI = SE.getPredicatedBackedgeTakenCount(L,
+                // predicates);
+                if (const llvm::SCEV *BTP = getBackedgeTakenCount(SE, P)) {
+                    llvm::errs() << "BackedgeTakenCount: " << *BTP << "\n";
+                    if (!llvm::isa<llvm::SCEVCouldNotCompute>(BTP)) {
+                        return addBackedgeTakenCount(B, P, BTP, SE, minDepth);
+                    } else {
+                        llvm::errs()
+                            << "SCEVCouldNotCompute from loop: " << *P << "\n";
+                    }
+                }
+            } else {
+                llvm::errs()
+                    << "Fail because symbols are not loop invariant in loop:\n"
+                    << *P << "\n";
+                if (auto b = L->getBounds(SE))
+                    llvm::errs()
+                        << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
+                        << "\nStep: " << *b->getStepValue()
+                        << "\nFinal: " << b->getFinalIVValue() << "\n";
+                for (auto s : symbols)
+                    llvm::errs() << *s << "\n";
+            }
+        }
+        return std::max(depth - 1, minDepth);
+    }
+    bool areSymbolsLoopInvariant(llvm::Loop *L,
+                                 llvm::ScalarEvolution &SE) const {
+        for (size_t i = 0; i < symbols.size(); ++i)
+            if ((!allZero(A(_, i + 1))) && (!SE.isLoopInvariant(symbols[i], L)))
+                return false;
+        return true;
+    }
+    static llvm::Optional<UnboundedAffineLoopNest>
+    construct(llvm::Loop *L, llvm::ScalarEvolution &SE) {
+        auto BT = getBackedgeTakenCount(SE, L);
+        if (!BT || llvm::isa<llvm::SCEVCouldNotCompute>(BT))
+            return {};
+        return UnboundedAffineLoopNest(L, BT, SE);
+    }
+    UnboundedAffineLoopNest(llvm::Loop *L, const llvm::SCEV *BT,
+                            llvm::ScalarEvolution &SE) {
+        IntMatrix B;
+        // once we're done assembling these, we'll concatenate A and B
+        size_t maxDepth = L->getLoopDepth();
+        // size_t maxNumSymbols = BT->getExpressionSize();
+        A.resize(0, 1, 1 + BT->getExpressionSize());
+        B.resize(0, maxDepth, maxDepth);
+        size_t minDepth = addBackedgeTakenCount(B, L, BT, SE, 0);
+        // We first check for loops in B that are shallower than minDepth
+        // we include all loops such that L->getLoopDepth() > minDepth
+        // note that the outer-most loop has a depth of 1.
+        // We turn these loops into `getAddRecExprs`s, so that we can
+        // add them as variables to `A`.
+        for (size_t d = 0; d < minDepth; ++d) {
+            // loop at depth d+1
+            llvm::Loop *P = nullptr;
+            // search B(_,end-d) for references
+            for (size_t i = 0; i < B.numRow(); ++i) {
+                if (int64_t Bid = B(i, end - d)) {
+                    if (!P) {
+                        // find P
+                        P = L;
+                        for (size_t r = d + 1; r < maxDepth; ++r)
+                            P = P->getParentLoop();
+                    }
+                    // TODO: find a more efficient way to get IntTyp
+                    llvm::Type *IntTyp = P->getInductionVariable(SE)->getType();
+                    addSymbol(SE.getAddRecExpr(SE.getZero(IntTyp),
+                                               SE.getOne(IntTyp), P,
+                                               llvm::SCEV::NoWrapMask),
+                              i, i + 1, Bid);
+                    llvm::errs() << "UnboundedAffineLoopNest iter i = " << i
+                                 << "A = " << A << "\n";
+                }
+            }
+        }
+        size_t depth = maxDepth - minDepth;
+        size_t N = A.numCol();
+        A.resizeCols(N + depth);
+        // copy the included loops from B into A
+        A(_, _(N, N + depth)) = B(_, _(0, depth));
+        // addZeroLowerBounds();
+        // NOTE: pruneBounds() is not legal here if we wish to use
+        // removeInnerMost later.
+        // pruneBounds();
+    }
+    [[nodiscard]] UnboundedAffineLoopNest removeInnerMost() const {
+        size_t innermostLoopInd = getNumSymbols();
+        IntMatrix B = A.deleteCol(innermostLoopInd);
+        SHOWLN(A);
+        SHOWLN(B);
+        // no loop may be conditioned on the innermost loop
+        // so we should be able to safely remove all constraints that reference
+        // it
+        for (size_t m = B.numRow(); m-- > 0;) {
+            if (A(m, innermostLoopInd)) {
+                // B(_(m,end-1),_) = B(_(m+1,end),_);
+                // make sure we're explicit about the order we copy rows
+                size_t M = B.numRow() - 1;
+                for (size_t r = m; r < M; ++r)
+                    B(r, _) = B(r + 1, _);
+                B.resizeRows(M);
+            }
+        }
+        SHOWLN(B);
+        return UnboundedAffineLoopNest(B, symbols);
+    }
+    void clear() {
+        A.resize(0, 1); // 0 x 1 so that getNumLoops() == 0
+        symbols.truncate(0);
+    }
+    void removeOuterMost(size_t numToRemove, llvm::Loop *L,
+                         llvm::ScalarEvolution &SE) {
+        // basically, we move the outermost loops to the symbols section,
+        // and add the appropriate addressees
+        size_t oldNumLoops = getNumLoops();
+        if (numToRemove >= oldNumLoops)
+            return clear();
+        size_t innermostLoopInd = getNumSymbols();
+        size_t numRemainingLoops = oldNumLoops - numToRemove;
+        auto [M, N] = A.size();
+        if (numRemainingLoops != numToRemove) {
+            Vector<int64_t> tmp;
+            if (numRemainingLoops > numToRemove) {
+                tmp.resizeForOverwrite(numToRemove);
+                for (size_t m = 0; m < M; ++m) {
+                    // fill tmp
+                    tmp = A(m, _(innermostLoopInd + numRemainingLoops, N));
+                    for (size_t i = innermostLoopInd;
+                         i < numRemainingLoops + innermostLoopInd; ++i)
+                        A(m, i + numToRemove) = A(m, i);
+                    A(m, _(numToRemove + innermostLoopInd, N)) = tmp;
+                }
+            } else {
+                tmp.resizeForOverwrite(numRemainingLoops);
+                for (size_t m = 0; m < M; ++m) {
+                    // fill tmp
+                    tmp = A(m, _(innermostLoopInd,
+                                 innermostLoopInd + numRemainingLoops));
+                    for (size_t i = innermostLoopInd;
+                         i < numToRemove + innermostLoopInd; ++i)
+                        A(m, i) = A(m, i + numRemainingLoops);
+                    A(m, _(numToRemove + innermostLoopInd, N)) = tmp;
+                }
+            }
+        } else
+            for (size_t m = 0; m < M; ++m)
+                for (size_t i = 0; i < numToRemove; ++i)
+                    std::swap(A(m, innermostLoopInd + i),
+                              A(m, innermostLoopInd + i + numToRemove));
+
+        for (size_t i = 0; i < numRemainingLoops; ++i)
+            L = L->getParentLoop();
+        // L is now inner most loop getting removed
+        for (size_t i = 0; i < numToRemove; ++i) {
+            llvm::Type *IntType = L->getInductionVariable(SE)->getType();
+            symbols.push_back(SE.getAddRecExpr(SE.getZero(IntType),
+                                               SE.getOne(IntType), L,
+                                               llvm::SCEV::NoWrapMask));
+        }
+        initComparator();
+    }
+    void initComparator() { C.init(A, EmptyMatrix<int64_t>{}, true); }
+    void addZeroLowerBounds() {
+        auto [M, N] = A.size();
+        if (!N)
+            return;
+        size_t numLoops = getNumLoops();
+        SHOWLN(A);
+        A.resizeRows(M + numLoops);
+        A(_(M, M + numLoops), _) = 0;
+        for (size_t i = 0; i < numLoops; ++i)
+            A(M + i, N - numLoops + i) = 1;
+        SHOW(getNumLoops());
+        CSHOW(M);
+        CSHOW(N);
+        CSHOWLN(A);
+        initComparator();
+        pruneBounds();
+    }
+
+    UnboundedAffineLoopNest(IntMatrix A,
+                            llvm::SmallVector<const llvm::SCEV *> symbols)
+        : SymbolicPolyhedra(std::move(A)), symbols(std::move(symbols)){};
+    UnboundedAffineLoopNest(IntMatrix A)
+        : SymbolicPolyhedra(std::move(A)), symbols({}){};
+    UnboundedAffineLoopNest() = default;
+
+    PtrVector<int64_t> getProgVars(size_t j) const {
+        return A(j, _(0, getNumSymbols()));
+    }
+    void removeLoopBang(size_t i) {
+        SHOW(i);
+        CSHOWLN(getNumSymbols());
+        fourierMotzkin(A, i + getNumSymbols());
+        pruneBounds();
+    }
+    [[nodiscard]] UnboundedAffineLoopNest removeLoop(size_t i) const {
+        UnboundedAffineLoopNest L{*this};
+        // UnboundedAffineLoopNest L = *this;
+        L.removeLoopBang(i);
+        return L;
+    }
+    llvm::SmallVector<UnboundedAffineLoopNest, 0> perm(PtrVector<unsigned> x) {
+        llvm::SmallVector<UnboundedAffineLoopNest, 0> ret;
+        // llvm::SmallVector<UnboundedAffineLoopNest, 0> ret;
+        ret.resize_for_overwrite(x.size());
+        ret.back() = *this;
+        for (size_t i = x.size() - 1; i != 0;) {
+            UnboundedAffineLoopNest &prev = ret[i];
+            size_t oldi = i;
+            ret[--i] = prev.removeLoop(x[oldi]);
+        }
+        return ret;
+    }
+    std::pair<IntMatrix, IntMatrix> bounds(size_t i) const {
+        const auto [numNeg, numPos] = countSigns(A, i);
+        std::pair<IntMatrix, IntMatrix> ret;
+        ret.first.resizeForOverwrite(numNeg, A.numCol());
+        ret.second.resizeForOverwrite(numPos, A.numCol());
+        size_t negCount = 0;
+        size_t posCount = 0;
+        for (size_t j = 0; j < A.numRow(); ++j) {
+            if (int64_t Aji = A(j, i))
+                (Aji < 0 ? ret.first : ret.second)(
+                    Aji < 0 ? negCount++ : posCount++, _) = A(j, _);
+        }
+        return ret;
+    }
+    llvm::SmallVector<std::pair<IntMatrix, IntMatrix>, 0>
+    getBounds(PtrVector<unsigned> x) {
+        llvm::SmallVector<std::pair<IntMatrix, IntMatrix>, 0> ret;
+        size_t i = x.size();
+        ret.resize_for_overwrite(i);
+        UnboundedAffineLoopNest tmp = *this;
+        while (true) {
+            size_t xi = x[--i];
+            ret[i] = tmp.bounds(xi);
+            if (i == 0)
+                break;
+            tmp.removeLoopBang(xi);
+        }
+        return ret;
+    }
+    // bool isEmpty(size_t numConst) const {
+    //     return static_cast<const SymbolicPolyhedra *>(this)->isEmpty(
+    //         getNumSymbols());
+    // }
+    // bool isEmptyBang(size_t numConst) {
+    //     return static_cast<SymbolicPolyhedra *>(this)->isEmptyBang(
+    //         getNumSymbols());
+    // }
+    bool zeroExtraIterationsUponExtending(size_t _i, bool extendLower) const {
+        SymbolicPolyhedra tmp{*this};
+        const size_t numPrevLoops = getNumLoops() - 1;
+        // SHOW(getNumLoops());
+        // SHOW(numPrevLoops);
+        // SHOW(A.numRow());
+        // SHOW(A.numCol());
+        // for (size_t i = 0; i < numPrevLoops; ++i)
+        // if (_i != i)
+        // tmp.removeLoopBang(i);
+
+        // for (size_t i = _i + 1; i < numPrevLoops; ++i)
+        // tmp.removeLoopBang(i);
+        for (size_t i = 0; i < numPrevLoops; ++i)
+            if (i != _i)
+                tmp.removeVariableAndPrune(i + getNumSymbols());
+        bool indep = true;
+        const size_t numConst = getNumSymbols();
+        for (size_t n = 0; n < tmp.A.numRow(); ++n)
+            if ((tmp.A(n, _i + numConst) != 0) &&
+                (tmp.A(n, numPrevLoops + numConst) != 0))
+                indep = false;
+        if (indep)
+            return false;
+        SymbolicPolyhedra margi{tmp};
+        margi.removeVariableAndPrune(numPrevLoops + getNumSymbols());
+        SymbolicPolyhedra tmp2;
+        llvm::errs() << "\nmargi="
+                     << "\n";
+        margi.dump();
+        llvm::errs() << "\ntmp="
+                     << "\n";
+        tmp.dump();
+        // margi contains extrema for `_i`
+        // we can substitute extended for value of `_i`
+        // in `tmp`
+        int64_t sign = 2 * extendLower - 1; // extendLower ? 1 : -1
+        for (size_t c = 0; c < margi.getNumInequalityConstraints(); ++c) {
+            int64_t Aci = margi.A(c, _i + numConst);
+            int64_t b = sign * Aci;
+            if (b <= 0)
+                continue;
+            tmp2 = tmp;
+            // increment to increase bound
+            // this is correct for both extending lower and extending upper
+            // lower: a'x + i + b >= 0 -> i >= -a'x - b
+            // upper: a'x - i + b >= 0 -> i <=  a'x + b
+            // to decrease the lower bound or increase the upper, we increment
+            // `b`
+            ++margi.A(c, 0);
+            // our approach here is to set `_i` equal to the extended bound
+            // and then check if the resulting polyhedra is empty.
+            // if not, then we may have >0 iterations.
+            for (size_t cc = 0; cc < tmp2.A.numRow(); ++cc) {
+                int64_t d = tmp2.A(cc, _i + numConst);
+                if (d == 0)
+                    continue;
+                d *= sign;
+                for (size_t v = 0; v < tmp2.A.numCol(); ++v)
+                    tmp2.A(cc, v) = b * tmp2.A(cc, v) - d * margi.A(c, v);
+            }
+            for (size_t cc = tmp2.A.numRow(); cc != 0;)
+                if (tmp2.A(--cc, numPrevLoops + numConst) == 0)
+                    eraseConstraint(tmp2.A, cc);
+            llvm::errs() << "\nc=" << c << "; tmp2="
+                         << "\n";
+            tmp2.dump();
+            if (!(tmp2.isEmpty()))
+                return false;
+        }
+        return true;
+    }
+
+    void printSymbol(llvm::raw_ostream &os, PtrVector<int64_t> x,
+                     int64_t mul) const {
+        bool printed = x[0] != 0;
+        if (printed)
+            os << mul * x[0];
+        for (size_t i = 1; i < x.size(); ++i)
+            if (int64_t xi = x[i] * mul) {
+                if (printed)
+                    os << (xi > 0 ? " + " : " - ");
+                printed = true;
+                int64_t absxi = std::abs(xi);
+                if (absxi != 1)
+                    os << absxi << " * ";
+                os << *symbols[i - 1];
+            }
+    }
+
+    // void printBound(llvm::raw_ostream &os, const IntMatrix &A, size_t i,
+    void printBound(llvm::raw_ostream &os, size_t i, int64_t sign) const {
+        const size_t numVar = getNumLoops();
+        const size_t numVarMinus1 = numVar - 1;
+        const size_t numConst = getNumSymbols();
+        for (size_t j = 0; j < A.numRow(); ++j) {
+            int64_t Aji = A(j, i + numConst) * sign;
+            if (Aji <= 0)
+                continue;
+            if (A(j, i + numConst) != sign) {
+                os << Aji << "*i_" << numVarMinus1 - i
+                   << ((sign < 0) ? " <= " : " >= ");
+            } else {
+                os << "i_" << numVarMinus1 - i
+                   << ((sign < 0) ? " <= " : " >= ");
+            }
+            PtrVector<int64_t> b = getProgVars(j);
+            bool printed = !allZero(b);
+            if (printed)
+                printSymbol(os, b, -sign);
+            for (size_t k = 0; k < numVar; ++k) {
+                if (k == i)
+                    continue;
+                if (int64_t lakj = A(j, k + numConst)) {
+                    if (lakj * sign > 0) {
+                        os << " - ";
+                    } else if (printed) {
+                        os << " + ";
+                    }
+                    lakj = std::abs(lakj);
+                    if (lakj != 1)
+                        os << lakj << "*";
+                    os << "i_" << numVarMinus1 - k;
+                    printed = true;
+                }
+            }
+            if (!printed)
+                os << 0;
+            os << "\n";
+        }
+    }
+    void printLowerBound(llvm::raw_ostream &os, size_t i) const {
+        printBound(os, i, 1);
+    }
+    void printUpperBound(llvm::raw_ostream &os, size_t i) const {
+        printBound(os, i, -1);
+    }
+    // prints loops from inner most to outer most.
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                         const UnboundedAffineLoopNest &alnb) {
+        UnboundedAffineLoopNest aln{alnb};
+        size_t numLoopsMinus1 = aln.getNumLoops() - 1;
+        SHOWLN(alnb.getNumLoops());
+        SHOWLN(aln.getNumLoops());
+        SHOWLN(alnb.A);
+        size_t i = 0;
+        while (true) {
+            os << "Loop " << numLoopsMinus1 - i << " lower bounds:\n";
+            aln.printLowerBound(os, i);
+            os << "Loop " << numLoopsMinus1 - i << " upper bounds:\n";
+            aln.printUpperBound(os, i);
+            if (i == numLoopsMinus1)
+                break;
+            aln.removeLoopBang(i++);
+        }
+        return os;
+    }
+    void dump() const { llvm::errs() << *this; }
+};
+
+// A*x >= 0
+// x >= 0
+struct AffineLoopNest {
+    [[no_unique_address]] IntMatrix A;
+    [[no_unique_address]] LinearSymbolicComparator C;
+    [[no_unique_address]] llvm::SmallVector<const llvm::SCEV *> symbols{};
+    size_t getNumSymbols() const { return 1 + symbols.size(); }
+    size_t getNumLoops() const { return A.numCol() - getNumSymbols(); }
+
+    size_t findIndex(const llvm::SCEV *v) const {
+        return findSymbolicIndex(symbols, v);
+    }
+
+    UnboundedAffineLoopNest rotate(PtrMatrix<int64_t> R) const {
+        const size_t numVar = getNumLoops();
+        assert(R.numCol() == numVar);
+        assert(R.numRow() == numVar);
+        const size_t numConst = getNumSymbols();
+        const auto [M, N] = A.size();
+        UnboundedAffineLoopNest ret;
+        ret.symbols = symbols;
+        IntMatrix &B = ret.A;
+        B.resizeForOverwrite(M + numVar, N);
+        B(_(0, M), _(begin, numConst)) = A(_, _(begin, numConst));
+        B(_(0, M), _(numConst, end)) = A(_, _(numConst, end)) * R;
+        B(_(M, end), _(0, numConst)) = 0;
+        B(_(M, end), _(numConst, end)) = R;
+        ret.initComparator();
+        llvm::errs() << "A = \n" << A << "\n";
+        llvm::errs() << "R = \n" << R << "\n";
+        llvm::errs() << "B = \n" << B << "\n";
+        return ret;
+    }
+
+    // add a symbol to row `r` of A
+    // we try to break down value `v`, so that adding
+    // N, N - 1, N - 3 only adds the variable `N`, and adds the constant offsets
+    [[nodiscard]] size_t addSymbol(IntMatrix &B, llvm::Loop *L,
+                                   const llvm::SCEV *v,
+                                   llvm::ScalarEvolution &SE, const size_t l,
+                                   const size_t u, int64_t mlt,
+                                   size_t minDepth) {
+        assert(u > l);
+        // first, we check if `v` in `Symbols`
+        if (size_t i = findIndex(v)) {
+            for (size_t j = l; j < u; ++j)
+                A(j, i) += mlt;
+            return minDepth;
+        } else if (llvm::Optional<int64_t> c = getConstantInt(v)) {
+            for (size_t j = l; j < u; ++j)
+                A(j, 0) += mlt * (*c);
+            return minDepth;
+        } else if (const llvm::SCEVAddExpr *ex =
+                       llvm::dyn_cast<const llvm::SCEVAddExpr>(v)) {
+            const llvm::SCEV *op0 = ex->getOperand(0);
+            const llvm::SCEV *op1 = ex->getOperand(1);
+            // // check if either op is a SCEVMinMaxExpr of the wrong kind
+            // // if so, check if we can simplify by moving the add inside.
+            // if (const llvm::SCEVAddRecExpr *ar0 =
+            //         llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
+            //     if (const llvm::SCEVMinMaxExpr *mm1 =
+            //             llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(op1)) {
+            //         llvm::errs() << "for SCEV:" << *ex << "\nwe
+            //         distribute:\n"
+            //                      << *SE.getAddExpr(ar0, mm1->getOperand(0),
+            //                                        llvm::SCEV::NoWrapMask)
+            //                      << "\n"
+            //                      << *SE.getAddExpr(ar0, mm1->getOperand(1),
+            //                                        llvm::SCEV::NoWrapMask)
+            //                      << "\n";
+            //     }
+            // } else if (const llvm::SCEVMinMaxExpr *mm0 =
+            //                llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(op0)) {
+            //     if (const llvm::SCEVAddRecExpr *ar1 =
+            //             llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
+            //     }
+            // }
+
+            size_t M = A.numRow();
+            minDepth = addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
+            if (M != A.numRow())
+                minDepth =
+                    addSymbol(B, L, op1, SE, M, A.numRow(), mlt, minDepth);
+            return addSymbol(B, L, op1, SE, l, u, mlt, minDepth);
+        } else if (const llvm::SCEVMulExpr *ex =
+                       llvm::dyn_cast<const llvm::SCEVMulExpr>(v)) {
+            if (auto op = getConstantInt(ex->getOperand(0))) {
+                return addSymbol(B, L, ex->getOperand(1), SE, l, u, mlt * (*op),
+                                 minDepth);
+            } else if (auto op = getConstantInt(ex->getOperand(1))) {
+                return addSymbol(B, L, ex->getOperand(0), SE, l, u, mlt * (*op),
+                                 minDepth);
+            }
+        } else if (const llvm::SCEVAddRecExpr *x =
+                       llvm::dyn_cast<const llvm::SCEVAddRecExpr>(v)) {
+            size_t recDepth = x->getLoop()->getLoopDepth();
+            if (x->isAffine()) {
+                minDepth =
+                    addSymbol(B, L, x->getOperand(0), SE, l, u, mlt, minDepth);
+                if (auto c = getConstantInt(x->getOperand(1))) {
+                    // swap order vs recDepth to go inner<->outer
+                    B(l, B.numCol() - recDepth) = mlt * (*c);
+                    return minDepth;
+                }
+                v = SE.getAddRecExpr(SE.getZero(x->getOperand(0)->getType()),
+                                     x->getOperand(1), x->getLoop(),
+                                     x->getNoWrapFlags());
+            }
+            // we only support affine SCEVAddRecExpr with constant steps
+            // we use a flag "minSupported", which defaults to 0
+            // 0 means we support all loops, as the outer most depth is 1
+            // Depth of 0 means toplevel.
+            minDepth = std::max(minDepth, recDepth);
+        } else if (const llvm::SCEVMinMaxExpr *ex =
+                       llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(v)) {
+            auto S = simplifyMinMax(SE, ex);
+            if (S != v)
+                return addSymbol(B, L, S, SE, l, u, mlt, minDepth);
+            bool isMin = llvm::isa<llvm::SCEVSMinExpr>(ex) ||
+                         llvm::isa<llvm::SCEVUMinExpr>(ex);
+            llvm::errs() << "llvm::SCEVMinMaxExpr: " << *ex
+                         << "\nisMin = " << isMin << "; mlt = " << mlt << "\n";
+            const llvm::SCEV *op0 = ex->getOperand(0);
+            const llvm::SCEV *op1 = ex->getOperand(1);
+            if (isMin ^
+                (mlt < 0)) { // we can represent this as additional constraints
+                size_t M = A.numRow();
+                A.resizeRows(M + u - l);
+                B.resizeRows(M + u - l);
+                size_t Mp = M + u - l;
+                A(_(M, Mp), _) = A(_(l, u), _);
+                B(_(M, Mp), _) = B(_(l, u), _);
+                minDepth = addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
+                minDepth = addSymbol(B, L, op1, SE, M, Mp, mlt, minDepth);
+            } else if (addRecMatchesLoop(op0, L)) {
+                return addSymbol(B, L, op1, SE, l, u, mlt, minDepth);
+            } else if (addRecMatchesLoop(op1, L)) {
+                return addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
+            } else {
+                // auto S = simplifyMinMax(SE, ex);
+                // if (S != v)
+                //     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
                 llvm::errs() << "Failing on llvm::SCEVMinMaxExpr = " << *ex
                              << "<<\n*L =" << *L << "\n";
                 SHOWLN(*op0);
@@ -528,10 +1146,6 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
         A.resizeCols(N + depth);
         // copy the included loops from B into A
         A(_, _(N, N + depth)) = B(_, _(0, depth));
-        // addZeroLowerBounds();
-        // NOTE: pruneBounds() is not legal here if we wish to use
-        // removeInnerMost later.
-        // pruneBounds();
     }
     [[nodiscard]] AffineLoopNest removeInnerMost() const {
         size_t innermostLoopInd = getNumSymbols();
@@ -609,60 +1223,58 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
         }
         initComparator();
     }
-    void initComparator() { C.init(A, EmptyMatrix<int64_t>{}, true); }
-    void addZeroLowerBounds() {
-        auto [M, N] = A.size();
-        if (!N)
-            return;
-        size_t numLoops = getNumLoops();
-        SHOWLN(A);
-        A.resizeRows(M + numLoops);
-        A(_(M, M + numLoops), _) = 0;
-        for (size_t i = 0; i < numLoops; ++i)
-            A(M + i, N - numLoops + i) = 1;
-        SHOW(getNumLoops());
-        CSHOW(M);
-        CSHOW(N);
-        CSHOWLN(A);
-        initComparator();
-        pruneBounds();
-    }
+    void initComparator() { C.initNonNegative(A, getNumLoops()); }
 
     AffineLoopNest(IntMatrix A, llvm::SmallVector<const llvm::SCEV *> symbols)
-        : SymbolicPolyhedra(std::move(A)), symbols(std::move(symbols)){};
-    AffineLoopNest(IntMatrix A)
-        : SymbolicPolyhedra(std::move(A)), symbols({}){};
+        : A(std::move(A)), symbols(std::move(symbols)) {
+        initComparator();
+    };
+    AffineLoopNest(IntMatrix A) : A(std::move(A)), symbols({}) {
+        initComparator();
+    };
     AffineLoopNest() = default;
-
-    AffineLoopNest rotate(PtrMatrix<int64_t> R, size_t numPeeled = 0) const {
-        SHOW(R.numCol());
-        CSHOW(numPeeled);
-        CSHOWLN(getNumLoops());
-        assert(R.numCol() + numPeeled == getNumLoops());
-        assert(R.numRow() + numPeeled == getNumLoops());
-        assert(numPeeled < getNumLoops());
-        const size_t numConst = getNumSymbols() + numPeeled;
-        const auto [M, N] = A.size();
-        AffineLoopNest ret;
-        ret.symbols = symbols;
-        IntMatrix &B = ret.A;
-        B.resizeForOverwrite(M, N);
-        B(_, _(begin, numConst)) = A(_, _(begin, numConst));
-        B(_, _(numConst, end)) = A(_, _(numConst, end)) * R;
-        ret.initComparator();
-        llvm::errs() << "A = \n" << A << "\n";
-        llvm::errs() << "R = \n" << R << "\n";
-        llvm::errs() << "B = \n" << B << "\n";
-        return ret;
-    }
 
     PtrVector<int64_t> getProgVars(size_t j) const {
         return A(j, _(0, getNumSymbols()));
     }
+    void pruneBounds() {
+        size_t numLoops = getNumLoops();
+        Vector<int64_t> diff{A.numCol()};
+        for (size_t j = A.numRow(); j;) {
+	    bool broke = false;
+            for (size_t i = --j; i;) {
+                if (A.numRow() <= 1)
+                    return;
+                diff = A(--i, _) - A(j, _);
+                if (C.greaterEqual(diff)) {
+                    eraseConstraint(A, i);
+                    C.initNonNegative(A, numLoops);
+                    --j; // `i < j`, and `i` has been removed
+                } else if (C.greaterEqual(diff *= -1)) {
+                    eraseConstraint(A, j);
+                    C.initNonNegative(A, numLoops);
+		    broke = true;
+                    break; // `j` is gone
+                }
+            }
+	    if (!broke){
+		// compare with x >= 0
+		for (size_t i = 0; i < numLoops; ++i) {
+		    diff = A(j, _);
+		    --diff(end - i);
+		    if (C.greaterEqual(diff)) {
+			eraseConstraint(A, j);
+			C.initNonNegative(A, numLoops);
+			break; // `j` is gone
+		    }
+		}
+            }
+        }
+    }
     void removeLoopBang(size_t i) {
         SHOW(i);
         CSHOWLN(getNumSymbols());
-        fourierMotzkin(A, i + getNumSymbols());
+        fourierMotzkinNonNegative(A, i + getNumSymbols());
         pruneBounds();
     }
     [[nodiscard]] AffineLoopNest removeLoop(size_t i) const {
@@ -712,16 +1324,19 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
         }
         return ret;
     }
-    // bool isEmpty(size_t numConst) const {
-    //     return static_cast<const SymbolicPolyhedra *>(this)->isEmpty(
-    //         getNumSymbols());
-    // }
-    // bool isEmptyBang(size_t numConst) {
-    //     return static_cast<SymbolicPolyhedra *>(this)->isEmptyBang(
-    //         getNumSymbols());
-    // }
+    void removeVariableAndPrune(const size_t i) {
+        fourierMotzkinNonNegative(A, i);
+        pruneBounds();
+    }
+    size_t getNumInequalityConstraints() const { return A.numRow(); }
+    bool isEmpty() const {
+        for (size_t r = 0; r < A.numRow(); ++r)
+            if (C.less(A(r, _)))
+                return true;
+        return false;
+    }
     bool zeroExtraIterationsUponExtending(size_t _i, bool extendLower) const {
-        SymbolicPolyhedra tmp{*this};
+        AffineLoopNest tmp{*this};
         const size_t numPrevLoops = getNumLoops() - 1;
         // SHOW(getNumLoops());
         // SHOW(numPrevLoops);
@@ -744,9 +1359,9 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
                 indep = false;
         if (indep)
             return false;
-        SymbolicPolyhedra margi{tmp};
+        AffineLoopNest margi{tmp};
         margi.removeVariableAndPrune(numPrevLoops + getNumSymbols());
-        SymbolicPolyhedra tmp2;
+        AffineLoopNest tmp2;
         llvm::errs() << "\nmargi="
                      << "\n";
         margi.dump();
@@ -758,8 +1373,7 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
         // in `tmp`
         int64_t sign = 2 * extendLower - 1; // extendLower ? 1 : -1
         for (size_t c = 0; c < margi.getNumInequalityConstraints(); ++c) {
-            int64_t Aci = margi.A(c, _i + numConst);
-            int64_t b = sign * Aci;
+            int64_t b = sign * margi.A(c, _i + numConst);
             if (b <= 0)
                 continue;
             tmp2 = tmp;
@@ -784,9 +1398,34 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
             for (size_t cc = tmp2.A.numRow(); cc != 0;)
                 if (tmp2.A(--cc, numPrevLoops + numConst) == 0)
                     eraseConstraint(tmp2.A, cc);
-            llvm::errs() << "\nc=" << c << "; tmp2="
-                         << "\n";
-            tmp2.dump();
+            if (!(tmp2.isEmpty()))
+                return false;
+        }
+	if (extendLower){
+	    // sign = 1
+            tmp2 = tmp;
+            // increment to increase bound
+            // this is correct for both extending lower and extending upper
+            // lower: a'x + i + b >= 0 -> i >= -a'x - b
+            // upper: a'x - i + b >= 0 -> i <=  a'x + b
+            // to decrease the lower bound or increase the upper, we increment
+            // `b`
+            // our approach here is to set `_i` equal to the extended bound
+            // and then check if the resulting polyhedra is empty.
+            // if not, then we may have >0 iterations.
+            for (size_t cc = 0; cc < tmp2.A.numRow(); ++cc) {
+                if (int64_t d = tmp2.A(cc, _i + numConst)){
+		    // lower bound is i >= 0
+		    // so setting equal to the extended lower bound now means that
+		    // i = -1
+		    // so we decrement `d` from the column
+		    tmp2.A(cc, 0) -= d;
+		    tmp2.A(cc, _i + numConst) = 0;
+		}
+            }
+            for (size_t cc = tmp2.A.numRow(); cc != 0;)
+                if (tmp2.A(--cc, numPrevLoops + numConst) == 0)
+                    eraseConstraint(tmp2.A, cc);
             if (!(tmp2.isEmpty()))
                 return false;
         }
@@ -852,6 +1491,7 @@ struct AffineLoopNest : SymbolicPolyhedra { //,
         }
     }
     void printLowerBound(llvm::raw_ostream &os, size_t i) const {
+        os << "i_" << getNumLoops() - 1 - i << " >= 0\n";
         printBound(os, i, 1);
     }
     void printUpperBound(llvm::raw_ostream &os, size_t i) const {

--- a/include/TestUtilities.hpp
+++ b/include/TestUtilities.hpp
@@ -16,6 +16,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
 #include <llvm/Support/Casting.h>
+#include <string>
 
 struct TestLoopFunction {
     llvm::LLVMContext ctx;
@@ -34,6 +35,7 @@ struct TestLoopFunction {
     llvm::AssumptionCache AC;
     llvm::ScalarEvolution SE;
     llvm::SmallVector<AffineLoopNest, 0> alns;
+    llvm::SmallVector<std::string, 0> names;
     // llvm::SmallVector<llvm::Value*> symbols;
     llvm::Value *ptr;
     size_t ptrIntOffset{0};
@@ -67,12 +69,13 @@ struct TestLoopFunction {
     }
     // for creating some black box value
     llvm::Value *loadValueFromPtr(llvm::Type *typ) {
+        names.emplace_back("value_" + std::to_string(names.size()));
         return builder.CreateAlignedLoad(
             typ,
             builder.CreateGEP(builder.getInt64Ty(), ptr,
                               llvm::SmallVector<llvm::Value *, 1>{
                                   builder.getInt64(ptrIntOffset++)}),
-            llvm::MaybeAlign(8));
+            llvm::MaybeAlign(8), names.back());
     }
     llvm::Value *createArray() { return loadValueFromPtr(builder.getPtrTy()); }
     llvm::Value *createInt64() {

--- a/test/dependence_test.cpp
+++ b/test/dependence_test.cpp
@@ -138,6 +138,7 @@ TEST(IndependentTest, BasicAssertions) {
     TestLoopFunction tlf;
     tlf.addLoop(std::move(Aloop), 2);
     auto &loop = tlf.alns.front();
+    // loop.pruneBounds();
 
     llvm::ScalarEvolution &SE{tlf.SE};
     llvm::Type *Int64 = tlf.builder.getInt64Ty();

--- a/test/orthogonalize_test.cpp
+++ b/test/orthogonalize_test.cpp
@@ -163,21 +163,21 @@ TEST(OrthogonalizeTest, BasicAssertions) {
     llvm::errs() << "A=" << newAln.A << "\n";
     // llvm::errs() << "b=" << PtrVector<MPoly>(newAln.aln->b);
     llvm::errs() << "Skewed loop nest:\n" << newAln << "\n";
-    auto loop3Count = newAln.countSigns(newAln.A, 3 + newAln.getNumSymbols());
+    auto loop3Count = countSigns(newAln.A, 3 + newAln.getNumSymbols());
     EXPECT_EQ(loop3Count.first, 2);
-    EXPECT_EQ(loop3Count.second, 2);
+    EXPECT_EQ(loop3Count.second, 1);
     newAln.removeLoopBang(3);
-    auto loop2Count = newAln.countSigns(newAln.A, 2 + newAln.getNumSymbols());
+    auto loop2Count = countSigns(newAln.A, 2 + newAln.getNumSymbols());
     EXPECT_EQ(loop2Count.first, 2);
-    EXPECT_EQ(loop2Count.second, 2);
+    EXPECT_EQ(loop2Count.second, 1);
     newAln.removeLoopBang(2);
-    auto loop1Count = newAln.countSigns(newAln.A, 1 + newAln.getNumSymbols());
+    auto loop1Count = countSigns(newAln.A, 1 + newAln.getNumSymbols());
     EXPECT_EQ(loop1Count.first, 1);
-    EXPECT_EQ(loop1Count.second, 1);
+    EXPECT_EQ(loop1Count.second, 0);
     newAln.removeLoopBang(1);
-    auto loop0Count = newAln.countSigns(newAln.A, 0 + newAln.getNumSymbols());
+    auto loop0Count = countSigns(newAln.A, 0 + newAln.getNumSymbols());
     EXPECT_EQ(loop0Count.first, 1);
-    EXPECT_EQ(loop0Count.second, 1);
+    EXPECT_EQ(loop0Count.second, 0);
     llvm::errs() << "New ArrayReferences:\n";
     for (auto &ar : newArrayRefs) {
         SHOW(ar.indexMatrix().numRow());
@@ -282,19 +282,19 @@ TEST(BadMul, BasicAssertions) {
     SHOWLN(newAln.A);
     // llvm::errs() << "b=" << PtrVector<MPoly>(newAln.aln->b);
     llvm::errs() << "Skewed loop nest:\n" << newAln << "\n";
-    auto loop2Count = newAln.countSigns(newAln.A, 2 + newAln.getNumSymbols());
+    auto loop2Count = countSigns(newAln.A, 2 + newAln.getNumSymbols());
     EXPECT_EQ(loop2Count.first, 1);
-    EXPECT_EQ(loop2Count.second, 1);
+    EXPECT_EQ(loop2Count.second, 0);
     newAln.removeLoopBang(2);
     SHOWLN(newAln.A);
-    auto loop1Count = newAln.countSigns(newAln.A, 1 + newAln.getNumSymbols());
+    auto loop1Count = countSigns(newAln.A, 1 + newAln.getNumSymbols());
     EXPECT_EQ(loop1Count.first, 1);
-    EXPECT_EQ(loop1Count.second, 1);
+    EXPECT_EQ(loop1Count.second, 0);
     newAln.removeLoopBang(1);
     SHOWLN(newAln.A);
-    auto loop0Count = newAln.countSigns(newAln.A, 0 + newAln.getNumSymbols());
+    auto loop0Count = countSigns(newAln.A, 0 + newAln.getNumSymbols());
     EXPECT_EQ(loop0Count.first, 1);
-    EXPECT_EQ(loop0Count.second, 1);
+    EXPECT_EQ(loop0Count.second, 0);
 
     llvm::errs() << "New ArrayReferences:\n";
     for (auto &ar : newArrayRefs)


### PR DESCRIPTION
I still need to extend this to Polyhedra more generally, so DependencePolyehdra can benefit.
That'll be a follow up PR, as tests pass.