### PR TITLE
Use Non-Negative Polyhedra

### DIFF
--- a/include/ArrayReference.hpp
+++ b/include/ArrayReference.hpp
@@ -24,7 +24,7 @@
 // this is because we want stride ranks to be in decreasing order
 struct ArrayReference {
     [[no_unique_address]] const llvm::SCEVUnknown *basePointer;
-    [[no_unique_address]] AffineLoopNest *loop;
+    [[no_unique_address]] AffineLoopNest<true> *loop;
     [[no_unique_address]] llvm::SmallVector<const llvm::SCEV *, 3> sizes;
     [[no_unique_address]] llvm::SmallVector<int64_t, 16> indices;
     [[no_unique_address]] llvm::SmallVector<const llvm::SCEV *, 3>
@@ -69,22 +69,22 @@ struct ArrayReference {
           indices(a.indices.size()), symbolicOffsets(a.symbolicOffsets) {
         indexMatrix() = newInds;
     }
-    ArrayReference(const ArrayReference &a, AffineLoopNest *loop,
+    ArrayReference(const ArrayReference &a, AffineLoopNest<true> *loop,
                    PtrMatrix<int64_t> newInds)
         : basePointer(a.basePointer), loop(loop), sizes(a.sizes),
           indices(a.indices.size()), symbolicOffsets(a.symbolicOffsets) {
         indexMatrix() = newInds;
     }
-    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest *loop)
+    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest<true> *loop)
         : basePointer(basePointer), loop(loop){};
-    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest &loop)
+    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest<true> &loop)
         : basePointer(basePointer), loop(&loop){};
-    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest *loop,
+    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest<true> *loop,
                    llvm::SmallVector<const llvm::SCEV *, 3> symbolicOffsets,
                    Predicates pred = {})
         : basePointer(basePointer), loop(loop),
           symbolicOffsets(std::move(symbolicOffsets)), pred(std::move(pred)){};
-    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest *loop,
+    ArrayReference(const llvm::SCEVUnknown *basePointer, AffineLoopNest<true> *loop,
                    llvm::SmallVector<const llvm::SCEV *, 3> sizes,
                    llvm::SmallVector<const llvm::SCEV *, 3> symbolicOffsets,
                    Predicates pred = {})
@@ -96,7 +96,7 @@ struct ArrayReference {
         indices.resize(d * (getNumLoops() + getNumSymbols()));
     }
     ArrayReference(
-        const llvm::SCEVUnknown *basePointer, AffineLoopNest *loop, size_t dim,
+        const llvm::SCEVUnknown *basePointer, AffineLoopNest<true> *loop, size_t dim,
         llvm::SmallVector<const llvm::SCEV *, 3> symbolicOffsets = {},
         Predicates pred = {})
         : basePointer(basePointer), loop(loop),
@@ -104,7 +104,7 @@ struct ArrayReference {
         resize(dim);
     };
     ArrayReference(
-        const llvm::SCEVUnknown *basePointer, AffineLoopNest &loop, size_t dim,
+        const llvm::SCEVUnknown *basePointer, AffineLoopNest<true> &loop, size_t dim,
         llvm::SmallVector<const llvm::SCEV *, 3> symbolicOffsets = {},
         Predicates pred = {})
         : basePointer(basePointer), loop(&loop),
@@ -175,7 +175,7 @@ struct ArrayReference {
                     if (j) {
                         if (offij != 1)
                             os << offij << '*';
-                        os << *ar.loop->symbols[j - 1];
+                        os << *ar.loop->S[j - 1];
                     } else
                         os << offij;
                     printPlus = true;

--- a/include/Comparators.hpp
+++ b/include/Comparators.hpp
@@ -401,12 +401,8 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
     // Note that this is only valid when the comparator was constructed
     // with index `0` referring to >= 0 constants (i.e., the default).
     bool isEmpty() {
-	SHOW(U.numRow());
-	CSHOWLN(U.numCol());
         StridedVector<int64_t> b{StridedVector<int64_t>(U(_, 0))};
         if (d.size() == 0) {
-            // SHOWLN(U.numCol());
-            // SHOWLN(query.size());
             for (size_t i = V.numRow(); i < b.size(); ++i)
                 if (b(i))
                     return false;
@@ -442,9 +438,6 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
             // expand W stores [c -JV2 JV2]
             //  we use simplex to solve [-JV2 JV2][y2+ y2-]' <= JV1D^(-1)Uq
             // where y2 = y2+ - y2-
-            // SHOWLN(V);
-            // SHOWLN(U);
-            // SHOWLN(c);
             IntMatrix expandW(numSlack, NSdim * 2 + 1);
             for (size_t i = 0; i < numSlack; ++i) {
                 expandW(i, 0) = c(i);
@@ -455,7 +448,6 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
                     expandW(i, j + NSdim + 1) = val;
                 }
             }
-            // SHOWLN(expandW);
             IntMatrix Wcouple{0, expandW.numCol()};
             llvm::Optional<Simplex> optS{
                 Simplex::positiveVariables(expandW, Wcouple)};
@@ -467,12 +459,8 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
     }
     bool greaterEqual(PtrVector<int64_t> query) const {
         Vector<int64_t> b = U(_, _(begin, query.size())) * query;
-        // SHOWLN(b);
-        // SHOWLN(d.size());
         // Full column rank case
         if (d.size() == 0) {
-            // SHOWLN(U.numCol());
-            // SHOWLN(query.size());
             for (size_t i = V.numRow(); i < b.size(); ++i)
                 if (b(i))
                     return false;
@@ -507,9 +495,6 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
             // expand W stores [c -JV2 JV2]
             //  we use simplex to solve [-JV2 JV2][y2+ y2-]' <= JV1D^(-1)Uq
             // where y2 = y2+ - y2-
-            // SHOWLN(V);
-            // SHOWLN(U);
-            // SHOWLN(c);
             IntMatrix expandW(numSlack, NSdim * 2 + 1);
             for (size_t i = 0; i < numSlack; ++i) {
                 expandW(i, 0) = c(i);
@@ -520,7 +505,6 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
                     expandW(i, j + NSdim + 1) = val;
                 }
             }
-            // SHOWLN(expandW);
             IntMatrix Wcouple{0, expandW.numCol()};
             llvm::Optional<Simplex> optS{
                 Simplex::positiveVariables(expandW, Wcouple)};

--- a/include/Comparators.hpp
+++ b/include/Comparators.hpp
@@ -401,6 +401,8 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
     // Note that this is only valid when the comparator was constructed
     // with index `0` referring to >= 0 constants (i.e., the default).
     bool isEmpty() {
+	SHOW(U.numRow());
+	CSHOWLN(U.numCol());
         StridedVector<int64_t> b{StridedVector<int64_t>(U(_, 0))};
         if (d.size() == 0) {
             // SHOWLN(U.numCol());

--- a/include/Comparators.hpp
+++ b/include/Comparators.hpp
@@ -273,6 +273,10 @@ struct LinearSymbolicComparator : BaseComparator<LinearSymbolicComparator> {
         numEquations = numCon;
         initCore();
     }
+    inline void initNonNegative(PtrMatrix<int64_t> A, EmptyMatrix<int64_t>,
+                                size_t numNonNegative) {
+        initNonNegative(A, numNonNegative);
+    }
     void initNonNegative(PtrMatrix<int64_t> A, size_t numNonNegative) {
         // we have an additional numNonNegative x numNonNegative identity matrix
         // as the lower right block of `A`.

--- a/include/Constraints.hpp
+++ b/include/Constraints.hpp
@@ -225,8 +225,9 @@ substituteEquality(IntMatrix &A, IntMatrix &E, const size_t i) {
 
 // C = [ I A
 //       0 B ]
-void slackEqualityConstraints(MutPtrMatrix<int64_t> C, PtrMatrix<int64_t> A,
-                              PtrMatrix<int64_t> B) {
+[[maybe_unused]] static void slackEqualityConstraints(MutPtrMatrix<int64_t> C,
+                                                      PtrMatrix<int64_t> A,
+                                                      PtrMatrix<int64_t> B) {
     const size_t numVar = A.numCol();
     assert(numVar == B.numCol());
     const size_t numSlack = A.numRow();
@@ -465,4 +466,10 @@ countSigns(PtrMatrix<int64_t> A, size_t i) {
         if (x[i] + y[i])
             return false;
     return true;
+}
+
+[[maybe_unused]] static void deleteBounds(IntMatrix &A, size_t i) {
+    for (size_t j = A.numRow(); j != 0;)
+        if (A(--j, i))
+            eraseConstraint(A, j);
 }

--- a/include/EmptyArrays.hpp
+++ b/include/EmptyArrays.hpp
@@ -48,5 +48,8 @@ template <typename T> struct EmptyVector {
 };
 
 template <typename T, typename S>
-concept MaybeVector = std::is_same_v<T, EmptyVector<S>> ||
-                      std::is_same_v<T, llvm::SmallVector<S>>;
+concept MaybeVector =
+    std::is_same_v<T, EmptyVector<S>> || std::is_same_v<T, PtrVector<S>> ||
+    std::is_same_v<T, MutPtrVector<S>> || std::is_same_v<T, StridedVector<S>> ||
+    std::is_same_v<T, MutStridedVector<S>> || std::is_same_v<T, Vector<S>> ||
+    std::is_same_v<T, llvm::SmallVector<S>>;

--- a/include/LoopBlock.hpp
+++ b/include/LoopBlock.hpp
@@ -672,13 +672,13 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
         for (auto &e : mem.edgesIn)
             if (!g.isInactive(e))
                 return true;
-            else
-                llvm::errs() << "hasActiveEdge In false for: " << edges[e];
+        // else
+        //     llvm::errs() << "hasActiveEdge In false for: " << edges[e];
         for (auto &e : mem.edgesOut)
             if (!g.isInactive(e))
                 return true;
-            else
-                llvm::errs() << "hasActiveEdge Out false for: " << edges[e];
+        // else
+        //     llvm::errs() << "hasActiveEdge Out false for: " << edges[e];
         return false;
     }
     [[nodiscard]] bool hasActiveEdges(const Graph &g, const MemoryAccess &mem,
@@ -686,15 +686,15 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
         for (auto &e : mem.edgesIn)
             if (!g.isInactive(e, d))
                 return true;
-            else
-                llvm::errs() << "hasActiveEdge In d = " << d
-                             << " false for: " << edges[e];
+        // else
+        //     llvm::errs() << "hasActiveEdge In d = " << d
+        //                  << " false for: " << edges[e];
         for (auto &e : mem.edgesOut)
             if (!g.isInactive(e, d))
                 return true;
-            else
-                llvm::errs() << "hasActiveEdge Out d = " << d
-                             << " false for: " << edges[e];
+        // else
+        //     llvm::errs() << "hasActiveEdge Out d = " << d
+        //                  << " false for: " << edges[e];
         return false;
     }
     [[nodiscard]] bool hasActiveEdges(const Graph &g, const ScheduledNode &node,

--- a/include/LoopBlock.hpp
+++ b/include/LoopBlock.hpp
@@ -638,7 +638,7 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
             const Dependence &edge = edges[e];
             size_t mlt = edge.in->nodeIndex.size() * edge.out->nodeIndex.size();
             a += mlt * edge.getNumLambda();
-            b += mlt * edge.depPoly.symbols.size();
+            b += mlt * edge.depPoly.S.size();
             c += mlt * edge.getNumConstraints();
             ae += mlt;
         }

--- a/include/LoopBlock.hpp
+++ b/include/LoopBlock.hpp
@@ -755,13 +755,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
                                 numOmegaCoefs + numLambda);
         auto C{omniSimplex.getConstraints()};
         C = 0;
-        llvm::errs() << "instantiateOmniSimplex, numActiveEdges = "
-                     << numActiveEdges << "\n";
-        // SHOW(numPhiCoefs);
-        // CSHOW(numOmegaCoefs);
-        // CSHOWLN(1 + numBounding + numActiveEdges + numPhiCoefs +
-        // numOmegaCoefs); SHOW(numBounding); CSHOW(numActiveEdges);
-        // CSHOWLN(numLambda);
         // layout of omniSimplex:
         // Order: C, then priority to minimize
         // all : C, u, w, Phis, omegas, lambdas
@@ -924,7 +917,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
         if (allZero(sol(_(begin, numBounding + numActiveEdges))))
             return {};
         size_t u = 0, w = numBounding;
-        // SHOWLN(sol);
         BitSet deactivated;
         for (size_t e = 0; e < edges.size(); ++e) {
             if (g.isInactive(e, d))
@@ -948,8 +940,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
     }
     void updateSchedules(const Graph &g, size_t depth) {
 #ifndef NDEBUG
-        // SHOW(depth);
-        // CSHOWLN(sol);
         if (depth & 1) {
             bool allZero = true;
             for (auto &s : sol) {
@@ -964,31 +954,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
             if (depth >= node.getNumLoops())
                 continue;
             if (!hasActiveEdges(g, node)) {
-                // #ifndef NDEBUG
-                //                 for (auto memId : node.memory) {
-                //                     auto &mem = *memory[memId];
-                //                     llvm::errs() << "no active edges in:\n"
-                //                     << mem << "\n\n"; for (auto &eId :
-                //                     mem.edgesIn) {
-                //                         auto &e = edges[eId];
-                //                         SHOWLN(g.activeEdges[eId]);
-                //                         CSHOW(e.in->nodeIndex);
-                //                         CSHOWLN(g.containsNode(e.in->nodeIndex));
-                //                         CSHOW(e.out->nodeIndex);
-                //                         CSHOWLN(g.containsNode(e.out->nodeIndex));
-                //                     }
-                //                     for (auto &eId : mem.edgesOut) {
-                //                         auto &e = edges[eId];
-                //                         SHOWLN(g.activeEdges[eId]);
-                //                         CSHOW(e.in->nodeIndex);
-                //                         CSHOWLN(g.containsNode(e.in->nodeIndex));
-                //                         CSHOW(e.out->nodeIndex);
-                //                         CSHOWLN(g.containsNode(e.out->nodeIndex));
-                //                     }
-                //                 }
-                //                 llvm::errs() << "NO ACTIVE EDGES?!? Depth = "
-                //                 << depth << "\n";
-                // #endif
                 node.schedule.getOffsetOmega()(depth) =
                     std::numeric_limits<int64_t>::min();
                 if (!node.phiIsScheduled(depth))
@@ -997,14 +962,10 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
                 continue;
             }
             node.schedule.getOffsetOmega()(depth) = sol(node.omegaOffset - 1);
-            // if (!node.phiIsScheduled(depth))
-            //     SHOWLN(sol(node.getPhiOffsetRange() - 1));
             if (!node.phiIsScheduled(depth)) {
                 auto phi = node.schedule.getPhi()(depth, _);
                 auto s = sol(node.getPhiOffsetRange() - 1);
                 int64_t l = denomLCM(s);
-                // SHOW(l);
-                // CSHOWLN(depth);
                 for (size_t i = 0; i < phi.size(); ++i)
                     assert(((s(i).numerator * l) / (s(i).denominator)) >= 0);
                 if (l == 1)
@@ -1013,14 +974,11 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
                 else
                     for (size_t i = 0; i < phi.size(); ++i)
                         phi(i) = (s(i).numerator * l) / (s(i).denominator);
-                SHOWLN(phi);
                 assert(!(allZero(phi)));
                 // node.schedule.getPhi()(depth, _) =
                 //     sol(node.getPhiOffset() - 1) *
                 //     denomLCM(sol(node.getPhiOffset() - 1));
             }
-            // SHOW(depth);
-            // CSHOWLN(node.schedule.getPhi()(depth, _));
 #ifndef NDEBUG
             if (!node.phiIsScheduled(depth)) {
                 int64_t l = denomLCM(sol(node.getPhiOffsetRange() - 1));
@@ -1064,7 +1022,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
             // sum(N,dims=1) >= 1 after flipping row signs to be lex > 0
             for (size_t m = 0; m < N.numRow(); ++m)
                 cc += N(m, _) * lexSign(N(m, _));
-            // SHOWLN(cc);
             c(end) = -1; // for >=
         }
         assert(!allZero(omniSimplex.getConstraints()(end, _)));
@@ -1208,7 +1165,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
         // set omegas for gp
         for (auto &&v : *gp)
             v.schedule.getFusionOmega()[d] = unfusedOffset;
-        SHOWLN(unfusedOffset);
         ++d;
         // size_t numSat = satDeps.size();
         for (auto i : baseGraphs)
@@ -1250,15 +1206,12 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
     //         omniSimplex.copySolution(sol);
     //     }
     [[nodiscard]] llvm::Optional<BitSet> optimizeLevel(Graph &g, size_t d) {
-        // CSHOW(numPhiCoefs);
-        // CSHOWLN(d);
         if (numPhiCoefs == 0) {
             setSchedulesIndependent(g, d);
             return BitSet{};
         }
         instantiateOmniSimplex(g, d);
         addIndependentSolutionConstraints(g, d);
-        // SHOWLN(omniSimplex);
         assert(!allZero(omniSimplex.getConstraints()(end, _)));
         if (omniSimplex.initiateFeasible()) {
             llvm::errs() << "optimizeLevel = " << d
@@ -1277,14 +1230,9 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
         // depSatLevel and depSatNest
         // what we want to know is, can we satisfy all the deps
         // in depSatNest?
-        SHOWLN(depSatLevel);
-        SHOWLN(depSatNest);
         depSatLevel |= depSatNest;
         const size_t numSatNest = depSatLevel.size();
-        SHOW(numSatNest);
-        CSHOWLN(depSatLevel);
         if (numSatNest) {
-
             // backup in case we fail
             // activeEdges was the old original; swap it in
             std::swap(g.activeEdges, activeEdges);
@@ -1303,7 +1251,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
             if (!omniSimplex.initiateFeasible()) {
                 sol.resizeForOverwrite(getLambdaOffset() - 1);
                 omniSimplex.lexMinimize(sol);
-                SHOWLN(sol);
                 // lexMinimize(g, sol, d);
                 updateSchedules(g, d);
                 BitSet depSat = deactivateSatisfiedEdges(g, d);
@@ -1330,8 +1277,6 @@ struct LoopBlock { // : BaseGraph<LoopBlock, ScheduledNode> {
             return BitSet{};
         countAuxParamsAndConstraints(g, d);
         setScheduleMemoryOffsets(g, d);
-        SHOW(d);
-        CSHOWLN(numPhiCoefs);
         // if we fail on this level, break the graph
         BitSet activeEdgesBackup = g.activeEdges;
         if (llvm::Optional<BitSet> depSat = optimizeLevel(g, d)) {

--- a/include/LoopForest.hpp
+++ b/include/LoopForest.hpp
@@ -246,7 +246,7 @@ struct LoopTree {
 
     // in addition to requiring simplify form, we require a single exit block
     [[no_unique_address]] llvm::SmallVector<PredicatedChain> paths;
-    [[no_unique_address]] AffineLoopNest affineLoop;
+    [[no_unique_address]] AffineLoopNest<true> affineLoop;
     [[no_unique_address]] unsigned parentLoop{
         std::numeric_limits<unsigned>::max()};
     [[no_unique_address]] llvm::SmallVector<MemoryAccess, 0> memAccesses{};
@@ -271,7 +271,8 @@ struct LoopTree {
 #endif
     }
 
-    LoopTree(llvm::Loop *L, AffineLoopNest aln, llvm::SmallVector<unsigned> sL,
+    LoopTree(llvm::Loop *L, AffineLoopNest<true> aln,
+             llvm::SmallVector<unsigned> sL,
              llvm::SmallVector<PredicatedChain> paths)
         : loop(L), subLoops(std::move(sL)), paths(std::move(paths)),
           affineLoop(std::move(aln)),
@@ -283,7 +284,7 @@ struct LoopTree {
                     assert(loop->contains(pbb.basicBlock));
 #endif
     }
-    // LoopTree(llvm::Loop *L, AffineLoopNest *aln, LoopForest sL)
+    // LoopTree(llvm::Loop *L, AffineLoopNest<true> *aln, LoopForest sL)
     // : loop(L), subLoops(sL), affineLoop(aln), parentLoop(nullptr) {}
 
     // LoopTree(llvm::Loop *L, LoopForest sL, unsigned affineLoopID)
@@ -471,7 +472,8 @@ struct LoopTree {
         llvm::errs() << "Starting second pass in pushBack\n";
         SHOWLN(subForest.size());
         if (subForest.size()) { // add subloops
-            AffineLoopNest &subNest = loopTrees[subForest.front()].affineLoop;
+            AffineLoopNest<true> &subNest =
+                loopTrees[subForest.front()].affineLoop;
             SHOWLN(subNest.getNumLoops());
             if (subNest.getNumLoops() > 1) {
                 visitedBBs.clear();

--- a/include/Loops.hpp
+++ b/include/Loops.hpp
@@ -388,47 +388,53 @@ struct AffineLoopNest
                 return addSymbol(B, L, op1, SE, l, u, mlt, minDepth);
             } else if (addRecMatchesLoop(op1, L)) {
                 return addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
-            } else {
-                // auto S = simplifyMinMax(SE, ex);
-                // if (S != v)
-                //     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
-                llvm::errs() << "Failing on llvm::SCEVMinMaxExpr = " << *ex
-                             << "<<\n*L =" << *L << "\n";
-                SHOWLN(*op0);
-                SHOWLN(*op1);
-                // TODO: don't only consider final value
-                // this assumes the final value is the maximum, which is not
-                // necessarilly true
-                if (auto op0ar = llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
-                    // auto op0final = SE.getSCEVAtScope(
-                    //     op0ar, op0ar->getLoop()->getParentLoop());
-                    auto op0final = SE.getSCEVAtScope(op0ar, nullptr);
-                    SHOWLN(*op0final);
-                    auto op0FinalMinusOp1 = SE.getMinusSCEV(op0final, op1);
-                    SHOWLN(SE.isKnownNonNegative(op0FinalMinusOp1));
-                    SHOWLN(SE.isKnownNonPositive(op0FinalMinusOp1));
-                    auto op0init = op0ar->getOperand(0);
-                    auto op0InitMinusOp1 = SE.getMinusSCEV(op0init, op1);
-                    SHOWLN(SE.isKnownNonNegative(op0InitMinusOp1));
-                    SHOWLN(SE.isKnownNonPositive(op0InitMinusOp1));
-                    auto op0step = op0ar->getOperand(0);
-                    SHOWLN(SE.isKnownNonNegative(op0step));
-                    SHOWLN(SE.isKnownNonPositive(op0step));
-                }
-                if (auto op1ar = llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
-                    SHOWLN(*SE.getSCEVAtScope(
-                        op1ar, op1ar->getLoop()->getParentLoop()));
-                }
-                auto op0MinusOp1 = SE.getMinusSCEV(op0, op1);
-                SHOWLN(SE.isKnownNonNegative(op0MinusOp1));
-                SHOWLN(SE.isKnownNonPositive(op0MinusOp1));
+                // } else {
+                //     // auto S = simplifyMinMax(SE, ex);
+                //     // if (S != v)
+                //     //     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
+                //     // llvm::errs() << "Failing on llvm::SCEVMinMaxExpr = "
+                //     << *ex
+                //     //              << "<<\n*L =" << *L << "\n";
+                //     // SHOWLN(*op0);
+                //     // SHOWLN(*op1);
+                //     // TODO: don't only consider final value
+                //     // this assumes the final value is the maximum, which is
+                //     not
+                //     // necessarilly true
+                //     if (auto op0ar =
+                //     llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
+                //         // auto op0final = SE.getSCEVAtScope(
+                //         //     op0ar, op0ar->getLoop()->getParentLoop());
+                //         auto op0final = SE.getSCEVAtScope(op0ar, nullptr);
+                //         SHOWLN(*op0final);
+                //         auto op0FinalMinusOp1 = SE.getMinusSCEV(op0final,
+                //         op1);
+                //         SHOWLN(SE.isKnownNonNegative(op0FinalMinusOp1));
+                //         SHOWLN(SE.isKnownNonPositive(op0FinalMinusOp1));
+                //         auto op0init = op0ar->getOperand(0);
+                //         auto op0InitMinusOp1 = SE.getMinusSCEV(op0init, op1);
+                //         SHOWLN(SE.isKnownNonNegative(op0InitMinusOp1));
+                //         SHOWLN(SE.isKnownNonPositive(op0InitMinusOp1));
+                //         auto op0step = op0ar->getOperand(0);
+                //         SHOWLN(SE.isKnownNonNegative(op0step));
+                //         SHOWLN(SE.isKnownNonPositive(op0step));
+                //     }
+                //     if (auto op1ar =
+                //     llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
+                //         SHOWLN(*SE.getSCEVAtScope(
+                //             op1ar, op1ar->getLoop()->getParentLoop()));
+                //     }
+                //     auto op0MinusOp1 = SE.getMinusSCEV(op0, op1);
+                //     // SHOWLN(SE.isKnownNonNegative(op0MinusOp1));
+                //     // SHOWLN(SE.isKnownNonPositive(op0MinusOp1));
 
-                if (auto b = L->getBounds(SE))
-                    llvm::errs()
-                        << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
-                        << "\nStep: " << *b->getStepValue()
-                        << "\nFinal: " << b->getFinalIVValue() << "\n";
-                assert(false);
+                //     if (auto b = L->getBounds(SE))
+                //         llvm::errs()
+                //             << "Loop Bounds:\nInitial: " <<
+                //             b->getInitialIVValue()
+                //             << "\nStep: " << *b->getStepValue()
+                //             << "\nFinal: " << b->getFinalIVValue() << "\n";
+                //     assert(false);
             }
         } else if (const llvm::SCEVCastExpr *ex =
                        llvm::dyn_cast<llvm::SCEVCastExpr>(v))
@@ -568,8 +574,6 @@ struct AffineLoopNest
     [[nodiscard]] AffineLoopNest<NonNegative> removeInnerMost() const {
         size_t innermostLoopInd = getNumSymbols();
         IntMatrix B = A.deleteCol(innermostLoopInd);
-        SHOWLN(A);
-        SHOWLN(B);
         // no loop may be conditioned on the innermost loop
         // so we should be able to safely remove all constraints that reference
         // it
@@ -583,7 +587,6 @@ struct AffineLoopNest
                 B.resizeRows(M);
             }
         }
-        SHOWLN(B);
         return AffineLoopNest<NonNegative>(B, S);
     }
     void clear() {
@@ -645,21 +648,16 @@ struct AffineLoopNest
         if (isEmpty())
             return;
         if constexpr (NonNegative)
-            return;
+            return pruneBounds();
         // return initializeComparator();
         auto [M, N] = A.size();
         if (!N)
             return;
         size_t numLoops = getNumLoops();
-        SHOWLN(A);
         A.resizeRows(M + numLoops);
         A(_(M, M + numLoops), _) = 0;
         for (size_t i = 0; i < numLoops; ++i)
             A(M + i, N - numLoops + i) = 1;
-        SHOW(getNumLoops());
-        CSHOW(M);
-        CSHOW(N);
-        CSHOWLN(A);
         initializeComparator();
         pruneBounds();
     }
@@ -678,8 +676,6 @@ struct AffineLoopNest
         return A(j, _(0, getNumSymbols()));
     }
     void removeLoopBang(size_t i) {
-        SHOW(i);
-        CSHOWLN(getNumSymbols());
         if constexpr (NonNegative)
             fourierMotzkinNonNegative(A, i + getNumSymbols());
         else
@@ -737,16 +733,6 @@ struct AffineLoopNest
     bool zeroExtraIterationsUponExtending(size_t _i, bool extendLower) const {
         AffineLoopNest<NonNegative> tmp{*this};
         const size_t numPrevLoops = getNumLoops() - 1;
-        // SHOW(getNumLoops());
-        // SHOW(numPrevLoops);
-        // SHOW(A.numRow());
-        // SHOW(A.numCol());
-        // for (size_t i = 0; i < numPrevLoops; ++i)
-        // if (_i != i)
-        // tmp.removeLoopBang(i);
-
-        // for (size_t i = _i + 1; i < numPrevLoops; ++i)
-        // tmp.removeLoopBang(i);
         for (size_t i = 0; i < numPrevLoops; ++i)
             if (i != _i)
                 tmp.removeVariableAndPrune(i + getNumSymbols());
@@ -761,12 +747,6 @@ struct AffineLoopNest
         AffineLoopNest<NonNegative> margi{tmp};
         margi.removeVariableAndPrune(numPrevLoops + getNumSymbols());
         AffineLoopNest<NonNegative> tmp2;
-        llvm::errs() << "\nmargi="
-                     << "\n";
-        margi.dump();
-        llvm::errs() << "\ntmp="
-                     << "\n";
-        tmp.dump();
         // margi contains extrema for `_i`
         // we can substitute extended for value of `_i`
         // in `tmp`

--- a/include/Loops.hpp
+++ b/include/Loops.hpp
@@ -135,7 +135,8 @@ noWrapSCEV(llvm::ScalarEvolution &SE, const llvm::SCEV *S) {
 //             return c->getSExtValue();
 //     return {};
 // }
-static llvm::Optional<int64_t> getConstantInt(const llvm::SCEV *v) {
+[[maybe_unused]] static llvm::Optional<int64_t>
+getConstantInt(const llvm::SCEV *v) {
     if (const llvm::SCEVConstant *sc =
             llvm::dyn_cast<const llvm::SCEVConstant>(v)) {
         llvm::ConstantInt *c = sc->getValue();
@@ -156,7 +157,7 @@ template <typename T>
 
 // returns 1-based index, to match the pattern we use where index 0 refers to a
 // constant offset this function returns 0 if S not found in `symbols`.
-[[nodiscard]] static size_t
+[[maybe_unused]] [[nodiscard]] static size_t
 findSymbolicIndex(llvm::ArrayRef<const llvm::SCEV *> symbols,
                   const llvm::SCEV *S) {
     for (size_t i = 0; i < symbols.size();)
@@ -225,10 +226,26 @@ simplifyMinMax(llvm::ScalarEvolution &SE, const llvm::SCEV *S) {
 // A * x >= 0
 // if constexpr(NonNegative)
 //   x >= 0
-template <bool NonNegative>
+template <bool NonNegative = true>
 struct AffineLoopNest
     : Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
                 llvm::SmallVector<const llvm::SCEV *>, NonNegative> {
+
+    using Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
+                    llvm::SmallVector<const llvm::SCEV *>,
+                    NonNegative>::getNumDynamic;
+    using Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
+                    llvm::SmallVector<const llvm::SCEV *>,
+                    NonNegative>::getNumSymbols;
+    using Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
+                    llvm::SmallVector<const llvm::SCEV *>,
+                    NonNegative>::pruneBounds;
+    using Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
+                    llvm::SmallVector<const llvm::SCEV *>, NonNegative>::A;
+    using Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
+                    llvm::SmallVector<const llvm::SCEV *>, NonNegative>::C;
+    using Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
+                    llvm::SmallVector<const llvm::SCEV *>, NonNegative>::S;
 
     constexpr size_t getNumLoops() const { return getNumDynamic(); }
 
@@ -420,11 +437,11 @@ struct AffineLoopNest
     void addSymbol(const llvm::SCEV *v, size_t l, size_t u, int64_t mlt) {
         assert(u > l);
         // llvm::errs() << "Before adding sym A = " << A << "\n";
-        symbols.push_back(v);
+        S.push_back(v);
         A.resizeCols(A.numCol() + 1);
         // A.insertZeroColumn(symbols.size());
         for (size_t j = l; j < u; ++j)
-            A(j, symbols.size()) = mlt;
+            A(j, S.size()) = mlt;
         // llvm::errs() << "After adding sym A = " << A << "\n";
     }
     static bool addRecMatchesLoop(const llvm::SCEV *S, llvm::Loop *L) {
@@ -473,7 +490,7 @@ struct AffineLoopNest
                         << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
                         << "\nStep: " << *b->getStepValue()
                         << "\nFinal: " << b->getFinalIVValue() << "\n";
-                for (auto s : symbols)
+                for (auto s : S)
                     llvm::errs() << *s << "\n";
             }
         }
@@ -481,8 +498,8 @@ struct AffineLoopNest
     }
     bool areSymbolsLoopInvariant(llvm::Loop *L,
                                  llvm::ScalarEvolution &SE) const {
-        for (size_t i = 0; i < symbols.size(); ++i)
-            if ((!allZero(A(_, i + 1))) && (!SE.isLoopInvariant(symbols[i], L)))
+        for (size_t i = 0; i < S.size(); ++i)
+            if ((!allZero(A(_, i + 1))) && (!SE.isLoopInvariant(S[i], L)))
                 return false;
         return true;
     }
@@ -559,11 +576,11 @@ struct AffineLoopNest
             }
         }
         SHOWLN(B);
-        return AffineLoopNest<NonNegative>(B, symbols);
+        return AffineLoopNest<NonNegative>(B, S);
     }
     void clear() {
         A.resize(0, 1); // 0 x 1 so that getNumLoops() == 0
-        symbols.truncate(0);
+        S.truncate(0);
     }
     void removeOuterMost(size_t numToRemove, llvm::Loop *L,
                          llvm::ScalarEvolution &SE) {
@@ -610,9 +627,9 @@ struct AffineLoopNest
         // L is now inner most loop getting removed
         for (size_t i = 0; i < numToRemove; ++i) {
             llvm::Type *IntType = L->getInductionVariable(SE)->getType();
-            symbols.push_back(SE.getAddRecExpr(SE.getZero(IntType),
-                                               SE.getOne(IntType), L,
-                                               llvm::SCEV::NoWrapMask));
+            S.push_back(SE.getAddRecExpr(SE.getZero(IntType),
+                                         SE.getOne(IntType), L,
+                                         llvm::SCEV::NoWrapMask));
         }
         initComparator();
     }
@@ -640,13 +657,11 @@ struct AffineLoopNest
     AffineLoopNest(IntMatrix A, llvm::SmallVector<const llvm::SCEV *> symbols)
         : Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
                     llvm::SmallVector<const llvm::SCEV *>, NonNegative>(
-              std::move(A)),
-          symbols(std::move(symbols)){};
+              std::move(A), std::move(symbols)){};
     AffineLoopNest(IntMatrix A)
         : Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
                     llvm::SmallVector<const llvm::SCEV *>, NonNegative>(
-              std::move(A)),
-          symbols({}){};
+              std::move(A)){};
     AffineLoopNest() = default;
 
     PtrVector<int64_t> getProgVars(size_t j) const {
@@ -662,18 +677,19 @@ struct AffineLoopNest
         pruneBounds();
     }
     [[nodiscard]] AffineLoopNest<NonNegative> removeLoop(size_t i) const {
-        UnboundedAffineLoopNest L{*this};
+        AffineLoopNest<NonNegative> L{*this};
         // UnboundedAffineLoopNest L = *this;
         L.removeLoopBang(i);
         return L;
     }
-    llvm::SmallVector<AffineLoopNest<NonNegative>, 0> perm(PtrVector<unsigned> x) {
-        llvm::SmallVector<UnboundedAffineLoopNest, 0> ret;
+    llvm::SmallVector<AffineLoopNest<NonNegative>, 0>
+    perm(PtrVector<unsigned> x) {
+        llvm::SmallVector<AffineLoopNest<NonNegative>, 0> ret;
         // llvm::SmallVector<UnboundedAffineLoopNest, 0> ret;
         ret.resize_for_overwrite(x.size());
         ret.back() = *this;
         for (size_t i = x.size() - 1; i != 0;) {
-            UnboundedAffineLoopNest &prev = ret[i];
+            AffineLoopNest<NonNegative> &prev = ret[i];
             size_t oldi = i;
             ret[--i] = prev.removeLoop(x[oldi]);
         }
@@ -698,7 +714,7 @@ struct AffineLoopNest
         llvm::SmallVector<std::pair<IntMatrix, IntMatrix>, 0> ret;
         size_t i = x.size();
         ret.resize_for_overwrite(i);
-        UnboundedAffineLoopNest tmp = *this;
+        AffineLoopNest<NonNegative> tmp = *this;
         while (true) {
             size_t xi = x[--i];
             ret[i] = tmp.bounds(xi);
@@ -716,664 +732,6 @@ struct AffineLoopNest
     //     return static_cast<SymbolicPolyhedra *>(this)->isEmptyBang(
     //         getNumSymbols());
     // }
-    bool zeroExtraIterationsUponExtending(size_t _i, bool extendLower) const {
-        SymbolicPolyhedra tmp{*this};
-        const size_t numPrevLoops = getNumLoops() - 1;
-        // SHOW(getNumLoops());
-        // SHOW(numPrevLoops);
-        // SHOW(A.numRow());
-        // SHOW(A.numCol());
-        // for (size_t i = 0; i < numPrevLoops; ++i)
-        // if (_i != i)
-        // tmp.removeLoopBang(i);
-
-        // for (size_t i = _i + 1; i < numPrevLoops; ++i)
-        // tmp.removeLoopBang(i);
-        for (size_t i = 0; i < numPrevLoops; ++i)
-            if (i != _i)
-                tmp.removeVariableAndPrune(i + getNumSymbols());
-        bool indep = true;
-        const size_t numConst = getNumSymbols();
-        for (size_t n = 0; n < tmp.A.numRow(); ++n)
-            if ((tmp.A(n, _i + numConst) != 0) &&
-                (tmp.A(n, numPrevLoops + numConst) != 0))
-                indep = false;
-        if (indep)
-            return false;
-        SymbolicPolyhedra margi{tmp};
-        margi.removeVariableAndPrune(numPrevLoops + getNumSymbols());
-        SymbolicPolyhedra tmp2;
-        llvm::errs() << "\nmargi="
-                     << "\n";
-        margi.dump();
-        llvm::errs() << "\ntmp="
-                     << "\n";
-        tmp.dump();
-        // margi contains extrema for `_i`
-        // we can substitute extended for value of `_i`
-        // in `tmp`
-        int64_t sign = 2 * extendLower - 1; // extendLower ? 1 : -1
-        for (size_t c = 0; c < margi.getNumInequalityConstraints(); ++c) {
-            int64_t Aci = margi.A(c, _i + numConst);
-            int64_t b = sign * Aci;
-            if (b <= 0)
-                continue;
-            tmp2 = tmp;
-            // increment to increase bound
-            // this is correct for both extending lower and extending upper
-            // lower: a'x + i + b >= 0 -> i >= -a'x - b
-            // upper: a'x - i + b >= 0 -> i <=  a'x + b
-            // to decrease the lower bound or increase the upper, we increment
-            // `b`
-            ++margi.A(c, 0);
-            // our approach here is to set `_i` equal to the extended bound
-            // and then check if the resulting polyhedra is empty.
-            // if not, then we may have >0 iterations.
-            for (size_t cc = 0; cc < tmp2.A.numRow(); ++cc) {
-                int64_t d = tmp2.A(cc, _i + numConst);
-                if (d == 0)
-                    continue;
-                d *= sign;
-                for (size_t v = 0; v < tmp2.A.numCol(); ++v)
-                    tmp2.A(cc, v) = b * tmp2.A(cc, v) - d * margi.A(c, v);
-            }
-            for (size_t cc = tmp2.A.numRow(); cc != 0;)
-                if (tmp2.A(--cc, numPrevLoops + numConst) == 0)
-                    eraseConstraint(tmp2.A, cc);
-            llvm::errs() << "\nc=" << c << "; tmp2="
-                         << "\n";
-            tmp2.dump();
-            if (!(tmp2.isEmpty()))
-                return false;
-        }
-        return true;
-    }
-
-    void printSymbol(llvm::raw_ostream &os, PtrVector<int64_t> x,
-                     int64_t mul) const {
-        bool printed = x[0] != 0;
-        if (printed)
-            os << mul * x[0];
-        for (size_t i = 1; i < x.size(); ++i)
-            if (int64_t xi = x[i] * mul) {
-                if (printed)
-                    os << (xi > 0 ? " + " : " - ");
-                printed = true;
-                int64_t absxi = std::abs(xi);
-                if (absxi != 1)
-                    os << absxi << " * ";
-                os << *symbols[i - 1];
-            }
-    }
-
-    // void printBound(llvm::raw_ostream &os, const IntMatrix &A, size_t i,
-    void printBound(llvm::raw_ostream &os, size_t i, int64_t sign) const {
-        const size_t numVar = getNumLoops();
-        const size_t numVarMinus1 = numVar - 1;
-        const size_t numConst = getNumSymbols();
-        for (size_t j = 0; j < A.numRow(); ++j) {
-            int64_t Aji = A(j, i + numConst) * sign;
-            if (Aji <= 0)
-                continue;
-            if (A(j, i + numConst) != sign) {
-                os << Aji << "*i_" << numVarMinus1 - i
-                   << ((sign < 0) ? " <= " : " >= ");
-            } else {
-                os << "i_" << numVarMinus1 - i
-                   << ((sign < 0) ? " <= " : " >= ");
-            }
-            PtrVector<int64_t> b = getProgVars(j);
-            bool printed = !allZero(b);
-            if (printed)
-                printSymbol(os, b, -sign);
-            for (size_t k = 0; k < numVar; ++k) {
-                if (k == i)
-                    continue;
-                if (int64_t lakj = A(j, k + numConst)) {
-                    if (lakj * sign > 0) {
-                        os << " - ";
-                    } else if (printed) {
-                        os << " + ";
-                    }
-                    lakj = std::abs(lakj);
-                    if (lakj != 1)
-                        os << lakj << "*";
-                    os << "i_" << numVarMinus1 - k;
-                    printed = true;
-                }
-            }
-            if (!printed)
-                os << 0;
-            os << "\n";
-        }
-    }
-    void printLowerBound(llvm::raw_ostream &os, size_t i) const {
-        printBound(os, i, 1);
-    }
-    void printUpperBound(llvm::raw_ostream &os, size_t i) const {
-        printBound(os, i, -1);
-    }
-    // prints loops from inner most to outer most.
-    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                         const UnboundedAffineLoopNest &alnb) {
-        UnboundedAffineLoopNest aln{alnb};
-        size_t numLoopsMinus1 = aln.getNumLoops() - 1;
-        SHOWLN(alnb.getNumLoops());
-        SHOWLN(aln.getNumLoops());
-        SHOWLN(alnb.A);
-        size_t i = 0;
-        while (true) {
-            os << "Loop " << numLoopsMinus1 - i << " lower bounds:\n";
-            aln.printLowerBound(os, i);
-            os << "Loop " << numLoopsMinus1 - i << " upper bounds:\n";
-            aln.printUpperBound(os, i);
-            if (i == numLoopsMinus1)
-                break;
-            aln.removeLoopBang(i++);
-        }
-        return os;
-    }
-    void dump() const { llvm::errs() << *this; }
-};
-
-// A*x >= 0
-// x >= 0
-struct AffineLoopNest {
-    [[no_unique_address]] IntMatrix A;
-    [[no_unique_address]] LinearSymbolicComparator C;
-    [[no_unique_address]] llvm::SmallVector<const llvm::SCEV *> symbols{};
-    size_t getNumSymbols() const { return 1 + symbols.size(); }
-    size_t getNumLoops() const { return A.numCol() - getNumSymbols(); }
-
-    size_t findIndex(const llvm::SCEV *v) const {
-        return findSymbolicIndex(symbols, v);
-    }
-
-    UnboundedAffineLoopNest rotate(PtrMatrix<int64_t> R) const {
-        const size_t numVar = getNumLoops();
-        assert(R.numCol() == numVar);
-        assert(R.numRow() == numVar);
-        const size_t numConst = getNumSymbols();
-        const auto [M, N] = A.size();
-        UnboundedAffineLoopNest ret;
-        ret.symbols = symbols;
-        IntMatrix &B = ret.A;
-        B.resizeForOverwrite(M + numVar, N);
-        B(_(0, M), _(begin, numConst)) = A(_, _(begin, numConst));
-        B(_(0, M), _(numConst, end)) = A(_, _(numConst, end)) * R;
-        B(_(M, end), _(0, numConst)) = 0;
-        B(_(M, end), _(numConst, end)) = R;
-        ret.initComparator();
-        llvm::errs() << "A = \n" << A << "\n";
-        llvm::errs() << "R = \n" << R << "\n";
-        llvm::errs() << "B = \n" << B << "\n";
-        return ret;
-    }
-
-    // add a symbol to row `r` of A
-    // we try to break down value `v`, so that adding
-    // N, N - 1, N - 3 only adds the variable `N`, and adds the constant offsets
-    [[nodiscard]] size_t addSymbol(IntMatrix &B, llvm::Loop *L,
-                                   const llvm::SCEV *v,
-                                   llvm::ScalarEvolution &SE, const size_t l,
-                                   const size_t u, int64_t mlt,
-                                   size_t minDepth) {
-        assert(u > l);
-        // first, we check if `v` in `Symbols`
-        if (size_t i = findIndex(v)) {
-            for (size_t j = l; j < u; ++j)
-                A(j, i) += mlt;
-            return minDepth;
-        } else if (llvm::Optional<int64_t> c = getConstantInt(v)) {
-            for (size_t j = l; j < u; ++j)
-                A(j, 0) += mlt * (*c);
-            return minDepth;
-        } else if (const llvm::SCEVAddExpr *ex =
-                       llvm::dyn_cast<const llvm::SCEVAddExpr>(v)) {
-            const llvm::SCEV *op0 = ex->getOperand(0);
-            const llvm::SCEV *op1 = ex->getOperand(1);
-            // // check if either op is a SCEVMinMaxExpr of the wrong kind
-            // // if so, check if we can simplify by moving the add inside.
-            // if (const llvm::SCEVAddRecExpr *ar0 =
-            //         llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
-            //     if (const llvm::SCEVMinMaxExpr *mm1 =
-            //             llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(op1)) {
-            //         llvm::errs() << "for SCEV:" << *ex << "\nwe
-            //         distribute:\n"
-            //                      << *SE.getAddExpr(ar0, mm1->getOperand(0),
-            //                                        llvm::SCEV::NoWrapMask)
-            //                      << "\n"
-            //                      << *SE.getAddExpr(ar0, mm1->getOperand(1),
-            //                                        llvm::SCEV::NoWrapMask)
-            //                      << "\n";
-            //     }
-            // } else if (const llvm::SCEVMinMaxExpr *mm0 =
-            //                llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(op0)) {
-            //     if (const llvm::SCEVAddRecExpr *ar1 =
-            //             llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
-            //     }
-            // }
-
-            size_t M = A.numRow();
-            minDepth = addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
-            if (M != A.numRow())
-                minDepth =
-                    addSymbol(B, L, op1, SE, M, A.numRow(), mlt, minDepth);
-            return addSymbol(B, L, op1, SE, l, u, mlt, minDepth);
-        } else if (const llvm::SCEVMulExpr *ex =
-                       llvm::dyn_cast<const llvm::SCEVMulExpr>(v)) {
-            if (auto op = getConstantInt(ex->getOperand(0))) {
-                return addSymbol(B, L, ex->getOperand(1), SE, l, u, mlt * (*op),
-                                 minDepth);
-            } else if (auto op = getConstantInt(ex->getOperand(1))) {
-                return addSymbol(B, L, ex->getOperand(0), SE, l, u, mlt * (*op),
-                                 minDepth);
-            }
-        } else if (const llvm::SCEVAddRecExpr *x =
-                       llvm::dyn_cast<const llvm::SCEVAddRecExpr>(v)) {
-            size_t recDepth = x->getLoop()->getLoopDepth();
-            if (x->isAffine()) {
-                minDepth =
-                    addSymbol(B, L, x->getOperand(0), SE, l, u, mlt, minDepth);
-                if (auto c = getConstantInt(x->getOperand(1))) {
-                    // swap order vs recDepth to go inner<->outer
-                    B(l, B.numCol() - recDepth) = mlt * (*c);
-                    return minDepth;
-                }
-                v = SE.getAddRecExpr(SE.getZero(x->getOperand(0)->getType()),
-                                     x->getOperand(1), x->getLoop(),
-                                     x->getNoWrapFlags());
-            }
-            // we only support affine SCEVAddRecExpr with constant steps
-            // we use a flag "minSupported", which defaults to 0
-            // 0 means we support all loops, as the outer most depth is 1
-            // Depth of 0 means toplevel.
-            minDepth = std::max(minDepth, recDepth);
-        } else if (const llvm::SCEVMinMaxExpr *ex =
-                       llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(v)) {
-            auto S = simplifyMinMax(SE, ex);
-            if (S != v)
-                return addSymbol(B, L, S, SE, l, u, mlt, minDepth);
-            bool isMin = llvm::isa<llvm::SCEVSMinExpr>(ex) ||
-                         llvm::isa<llvm::SCEVUMinExpr>(ex);
-            llvm::errs() << "llvm::SCEVMinMaxExpr: " << *ex
-                         << "\nisMin = " << isMin << "; mlt = " << mlt << "\n";
-            const llvm::SCEV *op0 = ex->getOperand(0);
-            const llvm::SCEV *op1 = ex->getOperand(1);
-            if (isMin ^
-                (mlt < 0)) { // we can represent this as additional constraints
-                size_t M = A.numRow();
-                A.resizeRows(M + u - l);
-                B.resizeRows(M + u - l);
-                size_t Mp = M + u - l;
-                A(_(M, Mp), _) = A(_(l, u), _);
-                B(_(M, Mp), _) = B(_(l, u), _);
-                minDepth = addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
-                minDepth = addSymbol(B, L, op1, SE, M, Mp, mlt, minDepth);
-            } else if (addRecMatchesLoop(op0, L)) {
-                return addSymbol(B, L, op1, SE, l, u, mlt, minDepth);
-            } else if (addRecMatchesLoop(op1, L)) {
-                return addSymbol(B, L, op0, SE, l, u, mlt, minDepth);
-            } else {
-                // auto S = simplifyMinMax(SE, ex);
-                // if (S != v)
-                //     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
-                llvm::errs() << "Failing on llvm::SCEVMinMaxExpr = " << *ex
-                             << "<<\n*L =" << *L << "\n";
-                SHOWLN(*op0);
-                SHOWLN(*op1);
-                // TODO: don't only consider final value
-                // this assumes the final value is the maximum, which is not
-                // necessarilly true
-                if (auto op0ar = llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
-                    // auto op0final = SE.getSCEVAtScope(
-                    //     op0ar, op0ar->getLoop()->getParentLoop());
-                    auto op0final = SE.getSCEVAtScope(op0ar, nullptr);
-                    SHOWLN(*op0final);
-                    auto op0FinalMinusOp1 = SE.getMinusSCEV(op0final, op1);
-                    SHOWLN(SE.isKnownNonNegative(op0FinalMinusOp1));
-                    SHOWLN(SE.isKnownNonPositive(op0FinalMinusOp1));
-                    auto op0init = op0ar->getOperand(0);
-                    auto op0InitMinusOp1 = SE.getMinusSCEV(op0init, op1);
-                    SHOWLN(SE.isKnownNonNegative(op0InitMinusOp1));
-                    SHOWLN(SE.isKnownNonPositive(op0InitMinusOp1));
-                    auto op0step = op0ar->getOperand(0);
-                    SHOWLN(SE.isKnownNonNegative(op0step));
-                    SHOWLN(SE.isKnownNonPositive(op0step));
-                }
-                if (auto op1ar = llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
-                    SHOWLN(*SE.getSCEVAtScope(
-                        op1ar, op1ar->getLoop()->getParentLoop()));
-                }
-                auto op0MinusOp1 = SE.getMinusSCEV(op0, op1);
-                SHOWLN(SE.isKnownNonNegative(op0MinusOp1));
-                SHOWLN(SE.isKnownNonPositive(op0MinusOp1));
-
-                if (auto b = L->getBounds(SE))
-                    llvm::errs()
-                        << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
-                        << "\nStep: " << *b->getStepValue()
-                        << "\nFinal: " << b->getFinalIVValue() << "\n";
-                assert(false);
-            }
-        } else if (const llvm::SCEVCastExpr *ex =
-                       llvm::dyn_cast<llvm::SCEVCastExpr>(v))
-            return addSymbol(B, L, ex->getOperand(0), SE, l, u, mlt, minDepth);
-        // } else if (const llvm::SCEVUDivExpr *ex = llvm::dyn_cast<const
-        // llvm::SCEVUDivExpr>(v)) {
-
-        // } else if (const llvm::SCEVUnknown *ex = llvm::dyn_cast<const
-        // llvm::SCEVUnknown>(v)) {
-        addSymbol(v, l, u, mlt);
-        return minDepth;
-    }
-    void addSymbol(const llvm::SCEV *v, size_t l, size_t u, int64_t mlt) {
-        assert(u > l);
-        // llvm::errs() << "Before adding sym A = " << A << "\n";
-        symbols.push_back(v);
-        A.resizeCols(A.numCol() + 1);
-        // A.insertZeroColumn(symbols.size());
-        for (size_t j = l; j < u; ++j)
-            A(j, symbols.size()) = mlt;
-        // llvm::errs() << "After adding sym A = " << A << "\n";
-    }
-    static bool addRecMatchesLoop(const llvm::SCEV *S, llvm::Loop *L) {
-        if (const llvm::SCEVAddRecExpr *x =
-                llvm::dyn_cast<const llvm::SCEVAddRecExpr>(S))
-            return x->getLoop() == L;
-        return false;
-    }
-    size_t addBackedgeTakenCount(IntMatrix &B, llvm::Loop *L,
-                                 const llvm::SCEV *BT,
-                                 llvm::ScalarEvolution &SE, size_t minDepth) {
-        size_t M = A.numRow();
-        A.resizeRows(M + 1);
-        B.resizeRows(M + 1);
-        llvm::errs() << "BT = " << *BT
-                     << "\naddBackedgeTakenCount pre addSym; M = " << M
-                     << "; A = " << A << "\n";
-        minDepth = addSymbol(B, L, BT, SE, M, M + 1, 1, minDepth);
-        llvm::errs() << "addBackedgeTakenCount post addSym; M = " << M
-                     << "; A = " << A << "\n";
-        assert(A.numRow() == B.numRow());
-        size_t depth = L->getLoopDepth();
-        for (size_t m = M; m < A.numRow(); ++m)
-            B(m, B.numCol() - depth) = -1; // indvar
-        // recurse, if possible to add an outer layer
-        if (llvm::Loop *P = L->getParentLoop()) {
-            if (areSymbolsLoopInvariant(P, SE)) {
-                // llvm::SmallVector<const llvm::SCEVPredicate *, 4> predicates;
-                // auto *BTI = SE.getPredicatedBackedgeTakenCount(L,
-                // predicates);
-                if (const llvm::SCEV *BTP = getBackedgeTakenCount(SE, P)) {
-                    llvm::errs() << "BackedgeTakenCount: " << *BTP << "\n";
-                    if (!llvm::isa<llvm::SCEVCouldNotCompute>(BTP)) {
-                        return addBackedgeTakenCount(B, P, BTP, SE, minDepth);
-                    } else {
-                        llvm::errs()
-                            << "SCEVCouldNotCompute from loop: " << *P << "\n";
-                    }
-                }
-            } else {
-                llvm::errs()
-                    << "Fail because symbols are not loop invariant in loop:\n"
-                    << *P << "\n";
-                if (auto b = L->getBounds(SE))
-                    llvm::errs()
-                        << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
-                        << "\nStep: " << *b->getStepValue()
-                        << "\nFinal: " << b->getFinalIVValue() << "\n";
-                for (auto s : symbols)
-                    llvm::errs() << *s << "\n";
-            }
-        }
-        return std::max(depth - 1, minDepth);
-    }
-    bool areSymbolsLoopInvariant(llvm::Loop *L,
-                                 llvm::ScalarEvolution &SE) const {
-        for (size_t i = 0; i < symbols.size(); ++i)
-            if ((!allZero(A(_, i + 1))) && (!SE.isLoopInvariant(symbols[i], L)))
-                return false;
-        return true;
-    }
-    static llvm::Optional<AffineLoopNest> construct(llvm::Loop *L,
-                                                    llvm::ScalarEvolution &SE) {
-        auto BT = getBackedgeTakenCount(SE, L);
-        if (!BT || llvm::isa<llvm::SCEVCouldNotCompute>(BT))
-            return {};
-        return AffineLoopNest(L, BT, SE);
-    }
-    AffineLoopNest(llvm::Loop *L, const llvm::SCEV *BT,
-                   llvm::ScalarEvolution &SE) {
-        IntMatrix B;
-        // once we're done assembling these, we'll concatenate A and B
-        size_t maxDepth = L->getLoopDepth();
-        // size_t maxNumSymbols = BT->getExpressionSize();
-        A.resize(0, 1, 1 + BT->getExpressionSize());
-        B.resize(0, maxDepth, maxDepth);
-        size_t minDepth = addBackedgeTakenCount(B, L, BT, SE, 0);
-        // We first check for loops in B that are shallower than minDepth
-        // we include all loops such that L->getLoopDepth() > minDepth
-        // note that the outer-most loop has a depth of 1.
-        // We turn these loops into `getAddRecExprs`s, so that we can
-        // add them as variables to `A`.
-        for (size_t d = 0; d < minDepth; ++d) {
-            // loop at depth d+1
-            llvm::Loop *P = nullptr;
-            // search B(_,end-d) for references
-            for (size_t i = 0; i < B.numRow(); ++i) {
-                if (int64_t Bid = B(i, end - d)) {
-                    if (!P) {
-                        // find P
-                        P = L;
-                        for (size_t r = d + 1; r < maxDepth; ++r)
-                            P = P->getParentLoop();
-                    }
-                    // TODO: find a more efficient way to get IntTyp
-                    llvm::Type *IntTyp = P->getInductionVariable(SE)->getType();
-                    addSymbol(SE.getAddRecExpr(SE.getZero(IntTyp),
-                                               SE.getOne(IntTyp), P,
-                                               llvm::SCEV::NoWrapMask),
-                              i, i + 1, Bid);
-                    llvm::errs() << "AffineLoopNest iter i = " << i
-                                 << "A = " << A << "\n";
-                }
-            }
-        }
-        size_t depth = maxDepth - minDepth;
-        size_t N = A.numCol();
-        A.resizeCols(N + depth);
-        // copy the included loops from B into A
-        A(_, _(N, N + depth)) = B(_, _(0, depth));
-    }
-    [[nodiscard]] AffineLoopNest removeInnerMost() const {
-        size_t innermostLoopInd = getNumSymbols();
-        IntMatrix B = A.deleteCol(innermostLoopInd);
-        SHOWLN(A);
-        SHOWLN(B);
-        // no loop may be conditioned on the innermost loop
-        // so we should be able to safely remove all constraints that reference
-        // it
-        for (size_t m = B.numRow(); m-- > 0;) {
-            if (A(m, innermostLoopInd)) {
-                // B(_(m,end-1),_) = B(_(m+1,end),_);
-                // make sure we're explicit about the order we copy rows
-                size_t M = B.numRow() - 1;
-                for (size_t r = m; r < M; ++r)
-                    B(r, _) = B(r + 1, _);
-                B.resizeRows(M);
-            }
-        }
-        SHOWLN(B);
-        return AffineLoopNest(B, symbols);
-    }
-    void clear() {
-        A.resize(0, 1); // 0 x 1 so that getNumLoops() == 0
-        symbols.truncate(0);
-    }
-    void removeOuterMost(size_t numToRemove, llvm::Loop *L,
-                         llvm::ScalarEvolution &SE) {
-        // basically, we move the outermost loops to the symbols section,
-        // and add the appropriate addressees
-        size_t oldNumLoops = getNumLoops();
-        if (numToRemove >= oldNumLoops)
-            return clear();
-        size_t innermostLoopInd = getNumSymbols();
-        size_t numRemainingLoops = oldNumLoops - numToRemove;
-        auto [M, N] = A.size();
-        if (numRemainingLoops != numToRemove) {
-            Vector<int64_t> tmp;
-            if (numRemainingLoops > numToRemove) {
-                tmp.resizeForOverwrite(numToRemove);
-                for (size_t m = 0; m < M; ++m) {
-                    // fill tmp
-                    tmp = A(m, _(innermostLoopInd + numRemainingLoops, N));
-                    for (size_t i = innermostLoopInd;
-                         i < numRemainingLoops + innermostLoopInd; ++i)
-                        A(m, i + numToRemove) = A(m, i);
-                    A(m, _(numToRemove + innermostLoopInd, N)) = tmp;
-                }
-            } else {
-                tmp.resizeForOverwrite(numRemainingLoops);
-                for (size_t m = 0; m < M; ++m) {
-                    // fill tmp
-                    tmp = A(m, _(innermostLoopInd,
-                                 innermostLoopInd + numRemainingLoops));
-                    for (size_t i = innermostLoopInd;
-                         i < numToRemove + innermostLoopInd; ++i)
-                        A(m, i) = A(m, i + numRemainingLoops);
-                    A(m, _(numToRemove + innermostLoopInd, N)) = tmp;
-                }
-            }
-        } else
-            for (size_t m = 0; m < M; ++m)
-                for (size_t i = 0; i < numToRemove; ++i)
-                    std::swap(A(m, innermostLoopInd + i),
-                              A(m, innermostLoopInd + i + numToRemove));
-
-        for (size_t i = 0; i < numRemainingLoops; ++i)
-            L = L->getParentLoop();
-        // L is now inner most loop getting removed
-        for (size_t i = 0; i < numToRemove; ++i) {
-            llvm::Type *IntType = L->getInductionVariable(SE)->getType();
-            symbols.push_back(SE.getAddRecExpr(SE.getZero(IntType),
-                                               SE.getOne(IntType), L,
-                                               llvm::SCEV::NoWrapMask));
-        }
-        initComparator();
-    }
-    void initComparator() { C.initNonNegative(A, getNumLoops()); }
-
-    AffineLoopNest(IntMatrix A, llvm::SmallVector<const llvm::SCEV *> symbols)
-        : A(std::move(A)), symbols(std::move(symbols)) {
-        initComparator();
-    };
-    AffineLoopNest(IntMatrix A) : A(std::move(A)), symbols({}) {
-        initComparator();
-    };
-    AffineLoopNest() = default;
-
-    PtrVector<int64_t> getProgVars(size_t j) const {
-        return A(j, _(0, getNumSymbols()));
-    }
-    void pruneBounds() {
-        size_t numLoops = getNumLoops();
-        Vector<int64_t> diff{A.numCol()};
-        for (size_t j = A.numRow(); j;) {
-            bool broke = false;
-            for (size_t i = --j; i;) {
-                if (A.numRow() <= 1)
-                    return;
-                diff = A(--i, _) - A(j, _);
-                if (C.greaterEqual(diff)) {
-                    eraseConstraint(A, i);
-                    C.initNonNegative(A, numLoops);
-                    --j; // `i < j`, and `i` has been removed
-                } else if (C.greaterEqual(diff *= -1)) {
-                    eraseConstraint(A, j);
-                    C.initNonNegative(A, numLoops);
-                    broke = true;
-                    break; // `j` is gone
-                }
-            }
-            if (!broke) {
-                // compare with x >= 0
-                for (size_t i = 0; i < numLoops; ++i) {
-                    diff = A(j, _);
-                    --diff(end - i);
-                    if (C.greaterEqual(diff)) {
-                        eraseConstraint(A, j);
-                        C.initNonNegative(A, numLoops);
-                        break; // `j` is gone
-                    }
-                }
-            }
-        }
-    }
-    void removeLoopBang(size_t i) {
-        SHOW(i);
-        CSHOWLN(getNumSymbols());
-        fourierMotzkinNonNegative(A, i + getNumSymbols());
-        pruneBounds();
-    }
-    [[nodiscard]] AffineLoopNest removeLoop(size_t i) const {
-        AffineLoopNest L{*this};
-        // AffineLoopNest L = *this;
-        L.removeLoopBang(i);
-        return L;
-    }
-    llvm::SmallVector<AffineLoopNest, 0> perm(PtrVector<unsigned> x) {
-        llvm::SmallVector<AffineLoopNest, 0> ret;
-        // llvm::SmallVector<AffineLoopNest, 0> ret;
-        ret.resize_for_overwrite(x.size());
-        ret.back() = *this;
-        for (size_t i = x.size() - 1; i != 0;) {
-            AffineLoopNest &prev = ret[i];
-            size_t oldi = i;
-            ret[--i] = prev.removeLoop(x[oldi]);
-        }
-        return ret;
-    }
-    std::pair<IntMatrix, IntMatrix> bounds(size_t i) const {
-        const auto [numNeg, numPos] = countSigns(A, i);
-        std::pair<IntMatrix, IntMatrix> ret;
-        ret.first.resizeForOverwrite(numNeg, A.numCol());
-        ret.second.resizeForOverwrite(numPos, A.numCol());
-        size_t negCount = 0;
-        size_t posCount = 0;
-        for (size_t j = 0; j < A.numRow(); ++j) {
-            if (int64_t Aji = A(j, i))
-                (Aji < 0 ? ret.first : ret.second)(
-                    Aji < 0 ? negCount++ : posCount++, _) = A(j, _);
-        }
-        return ret;
-    }
-    llvm::SmallVector<std::pair<IntMatrix, IntMatrix>, 0>
-    getBounds(PtrVector<unsigned> x) {
-        llvm::SmallVector<std::pair<IntMatrix, IntMatrix>, 0> ret;
-        size_t i = x.size();
-        ret.resize_for_overwrite(i);
-        AffineLoopNest tmp = *this;
-        while (true) {
-            size_t xi = x[--i];
-            ret[i] = tmp.bounds(xi);
-            if (i == 0)
-                break;
-            tmp.removeLoopBang(xi);
-        }
-        return ret;
-    }
-    void removeVariableAndPrune(const size_t i) {
-        fourierMotzkinNonNegative(A, i);
-        pruneBounds();
-    }
-    size_t getNumInequalityConstraints() const { return A.numRow(); }
-    bool isEmpty() const {
-        for (size_t r = 0; r < A.numRow(); ++r)
-            if (C.less(A(r, _)))
-                return true;
-        return false;
-    }
     bool zeroExtraIterationsUponExtending(size_t _i, bool extendLower) const {
         AffineLoopNest tmp{*this};
         const size_t numPrevLoops = getNumLoops() - 1;
@@ -1440,32 +798,33 @@ struct AffineLoopNest {
             if (!(tmp2.isEmpty()))
                 return false;
         }
-        if (extendLower) {
-            // sign = 1
-            tmp2 = tmp;
-            // increment to increase bound
-            // this is correct for both extending lower and extending upper
-            // lower: a'x + i + b >= 0 -> i >= -a'x - b
-            // upper: a'x - i + b >= 0 -> i <=  a'x + b
-            // to decrease the lower bound or increase the upper, we increment
-            // `b`
-            // our approach here is to set `_i` equal to the extended bound
-            // and then check if the resulting polyhedra is empty.
-            // if not, then we may have >0 iterations.
-            for (size_t cc = 0; cc < tmp2.A.numRow(); ++cc) {
-                if (int64_t d = tmp2.A(cc, _i + numConst)) {
-                    // lower bound is i >= 0
-                    // so setting equal to the extended lower bound now means
-                    // that i = -1 so we decrement `d` from the column
-                    tmp2.A(cc, 0) -= d;
-                    tmp2.A(cc, _i + numConst) = 0;
+        if constexpr (NonNegative) {
+            if (extendLower) {
+                // sign = 1
+                tmp2 = tmp;
+                // increment to increase bound
+                // this is correct for both extending lower and extending upper
+                // lower: a'x + i + b >= 0 -> i >= -a'x - b
+                // upper: a'x - i + b >= 0 -> i <=  a'x + b
+                // to decrease the lower bound or increase the upper, we
+                // increment `b` our approach here is to set `_i` equal to the
+                // extended bound and then check if the resulting polyhedra is
+                // empty. if not, then we may have >0 iterations.
+                for (size_t cc = 0; cc < tmp2.A.numRow(); ++cc) {
+                    if (int64_t d = tmp2.A(cc, _i + numConst)) {
+                        // lower bound is i >= 0
+                        // so setting equal to the extended lower bound now
+                        // means that i = -1 so we decrement `d` from the column
+                        tmp2.A(cc, 0) -= d;
+                        tmp2.A(cc, _i + numConst) = 0;
+                    }
                 }
+                for (size_t cc = tmp2.A.numRow(); cc != 0;)
+                    if (tmp2.A(--cc, numPrevLoops + numConst) == 0)
+                        eraseConstraint(tmp2.A, cc);
+                if (!(tmp2.isEmpty()))
+                    return false;
             }
-            for (size_t cc = tmp2.A.numRow(); cc != 0;)
-                if (tmp2.A(--cc, numPrevLoops + numConst) == 0)
-                    eraseConstraint(tmp2.A, cc);
-            if (!(tmp2.isEmpty()))
-                return false;
         }
         return true;
     }
@@ -1483,7 +842,7 @@ struct AffineLoopNest {
                 int64_t absxi = std::abs(xi);
                 if (absxi != 1)
                     os << absxi << " * ";
-                os << *symbols[i - 1];
+                os << *S[i - 1];
             }
     }
 
@@ -1529,7 +888,8 @@ struct AffineLoopNest {
         }
     }
     void printLowerBound(llvm::raw_ostream &os, size_t i) const {
-        os << "i_" << getNumLoops() - 1 - i << " >= 0\n";
+        if constexpr (NonNegative)
+            os << "i_" << getNumLoops() - 1 - i << " >= 0\n";
         printBound(os, i, 1);
     }
     void printUpperBound(llvm::raw_ostream &os, size_t i) const {
@@ -1538,7 +898,7 @@ struct AffineLoopNest {
     // prints loops from inner most to outer most.
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                          const AffineLoopNest &alnb) {
-        AffineLoopNest aln{alnb};
+        AffineLoopNest<NonNegative> aln{alnb};
         size_t numLoopsMinus1 = aln.getNumLoops() - 1;
         SHOWLN(alnb.getNumLoops());
         SHOWLN(aln.getNumLoops());

--- a/include/Polyhedra.hpp
+++ b/include/Polyhedra.hpp
@@ -18,6 +18,13 @@
 #include <sys/types.h>
 #include <type_traits>
 
+[[maybe_unused]] static llvm::raw_ostream &printPositive(llvm::raw_ostream &os,
+                                                         size_t stop) {
+    for (size_t i = 0; i < stop; ++i)
+        os << "v_" << i << " >= 0\n";
+    return os;
+}
+
 // Can we represent Polyhedra using slack variables + equalities?
 // What must we do with Polyhedra?
 // 1) A*x >= 0 && c'x >= 0 <-> l_0 + l'Ax == c'x && l >= 0 && l_0 >= 0
@@ -204,6 +211,8 @@ struct Polyhedra {
                                          const Polyhedra &p) {
         auto &&os2 = printConstraints(os << "\n", p.A,
                                       llvm::ArrayRef<const llvm::SCEV *>());
+        if constexpr (NonNegative)
+            printPositive(os2, p.getNumDynamic());
         if constexpr (hasEqualities)
             return printConstraints(
                 os2, p.E, llvm::ArrayRef<const llvm::SCEV *>(), false);

--- a/include/Polyhedra.hpp
+++ b/include/Polyhedra.hpp
@@ -88,14 +88,14 @@ struct Polyhedra {
             C.init(A, E);
         }
     }
+    bool calcIsEmpty() { return C.isEmpty(); }
     void pruneBounds() {
-        if (C.isEmpty()) {
+        if (calcIsEmpty()) {
             A.truncateRows(0);
             if constexpr (hasEqualities)
                 E.truncateRows(0);
-            return;
-        }
-        pruneBoundsUnchecked();
+        } else
+            pruneBoundsUnchecked();
     }
     void pruneBoundsUnchecked() {
         const size_t dyn = getNumDynamic();
@@ -211,7 +211,7 @@ struct Polyhedra {
     }
     void dump() const { llvm::errs() << *this; }
     bool isEmpty() const {
-	return A.numRow() == 0;
+        return A.numRow() == 0;
         // if (A.numRow() == 0)
         //     return true;
         // for (size_t r = 0; r < A.numRow(); ++r)

--- a/include/Polyhedra.hpp
+++ b/include/Polyhedra.hpp
@@ -70,9 +70,15 @@ struct Polyhedra {
 
     Polyhedra() = default;
     Polyhedra(IntMatrix Ain)
-        : A(std::move(Ain)), E{}, C(LinearSymbolicComparator::construct(A)){};
+        : E{}, A(std::move(Ain)), C(LinearSymbolicComparator::construct(A)){};
     Polyhedra(IntMatrix Ain, I64Matrix Ein)
-        : A(std::move(Ain)), E(std::move(Ein)),
+        : E(std::move(Ein)), A(std::move(Ain)),
+          C(LinearSymbolicComparator::construct(A)){};
+    Polyhedra(IntMatrix Ain, SymbolVec S)
+        : E{}, S(std::move(S)), A(std::move(Ain)),
+          C(LinearSymbolicComparator::construct(A)){};
+    Polyhedra(IntMatrix Ain, I64Matrix Ein, SymbolVec S)
+        : E(std::move(Ein)), S(std::move(S)), A(std::move(Ain)),
           C(LinearSymbolicComparator::construct(A)){};
 
     inline void initializeComparator() {
@@ -129,8 +135,10 @@ struct Polyhedra {
         }
     }
 
-    constexpr size_t getNumSymbols() const { return 1+ S.size(); }
-    constexpr size_t getNumDynamic() const { return A.numCol() - getNumSymbols(); }
+    constexpr size_t getNumSymbols() const { return 1 + S.size(); }
+    constexpr size_t getNumDynamic() const {
+        return A.numCol() - getNumSymbols();
+    }
     constexpr size_t getNumVar() const { return A.numCol() - 1; }
     constexpr size_t getNumInequalityConstraints() const { return A.numRow(); }
     constexpr size_t getNumEqualityConstraints() const { return E.numRow(); }
@@ -224,5 +232,8 @@ typedef Polyhedra<EmptyMatrix<int64_t>, LinearSymbolicComparator,
                   llvm::SmallVector<const llvm::SCEV *>, true>
     NonNegativeSymbolicPolyhedra;
 typedef Polyhedra<IntMatrix, LinearSymbolicComparator,
-                  EmptyVector<const llvm::SCEV *>, false>
+                  llvm::SmallVector<const llvm::SCEV *>, false>
     SymbolicEqPolyhedra;
+typedef Polyhedra<IntMatrix, LinearSymbolicComparator,
+                  llvm::SmallVector<const llvm::SCEV *>, true>
+    NonNegativeSymbolicEqPolyhedra;

--- a/include/Polyhedra.hpp
+++ b/include/Polyhedra.hpp
@@ -83,7 +83,7 @@ struct Polyhedra {
 
     inline void initializeComparator() {
         if constexpr (NonNegative) {
-            C.initNonNegative(A, E, getNumVar());
+            C.initNonNegative(A, E, getNumDynamic());
         } else {
             C.init(A, E);
         }
@@ -211,12 +211,13 @@ struct Polyhedra {
     }
     void dump() const { llvm::errs() << *this; }
     bool isEmpty() const {
-        if (A.numRow() == 0)
-            return true;
-        for (size_t r = 0; r < A.numRow(); ++r)
-            if (C.less(A(r, _)))
-                return true;
-        return false;
+	return A.numRow() == 0;
+        // if (A.numRow() == 0)
+        //     return true;
+        // for (size_t r = 0; r < A.numRow(); ++r)
+        //     if (C.less(A(r, _)))
+        //         return true;
+        // return false;
     }
     void truncateVars(size_t numVar) {
         if constexpr (hasEqualities)

--- a/include/Polyhedra.hpp
+++ b/include/Polyhedra.hpp
@@ -54,7 +54,7 @@
 // We have `A.numRow()` inequality constraints and `E.numRow()` equality
 // constraints.
 //
-template <MaybeMatrix<int64_t> I64Matrix, Comparator CmptrType>
+template <MaybeMatrix<int64_t> I64Matrix, Comparator CmptrType, bool NonNegative>
 struct Polyhedra {
     // order of vars:
     // constants, loop vars, symbolic vars

--- a/include/TestUtilities.hpp
+++ b/include/TestUtilities.hpp
@@ -34,7 +34,7 @@ struct TestLoopFunction {
     llvm::TargetLibraryInfo TLI;
     llvm::AssumptionCache AC;
     llvm::ScalarEvolution SE;
-    llvm::SmallVector<AffineLoopNest, 0> alns;
+    llvm::SmallVector<AffineLoopNest<true>, 0> alns;
     llvm::SmallVector<std::string, 0> names;
     // llvm::SmallVector<llvm::Value*> symbols;
     llvm::Value *ptr;
@@ -52,16 +52,16 @@ struct TestLoopFunction {
             // we're going to assume there's some chance of recycling old
             // symbols, so we are only going to be creating new ones if we have
             // to.
-            AffineLoopNest *symbolSource = nullptr;
+            AffineLoopNest<true> *symbolSource = nullptr;
             size_t numSymbolSource = 0;
             for (auto &aln : alns) {
-                if (numSymbolSource < aln.symbols.size()) {
-                    numSymbolSource = aln.symbols.size();
+                if (numSymbolSource < aln.S.size()) {
+                    numSymbolSource = aln.S.size();
                     symbolSource = &aln;
                 }
             }
             for (size_t i = 0; i < std::min(numSym, numSymbolSource); ++i)
-                symbols.push_back(symbolSource->symbols[i]);
+                symbols.push_back(symbolSource->S[i]);
             for (size_t i = numSymbolSource; i < numSym; ++i)
                 symbols.push_back(SE.getUnknown(createInt64()));
         }

--- a/include/TurboLoop.hpp
+++ b/include/TurboLoop.hpp
@@ -73,7 +73,7 @@ class TurboLoopPass : public llvm::PassInfoMixin<TurboLoopPass> {
   public:
     llvm::PreservedAnalyses run(llvm::Function &F,
                                 llvm::FunctionAnalysisManager &AM);
-    // llvm::SmallVector<AffineLoopNest, 0> affineLoopNests;
+    // llvm::SmallVector<AffineLoopNest<true>, 0> affineLoopNests;
     // one reason to prefer SmallVector is because it bounds checks `ifndef
     // NDEBUG`
     llvm::SmallVector<LoopTree, 0> loopTrees;
@@ -91,7 +91,7 @@ class TurboLoopPass : public llvm::PassInfoMixin<TurboLoopPass> {
 
     // the process of building the LoopForest has the following steps:
     // 1. build initial forest of trees
-    // 2. instantiate AffineLoopNests; any non-affine loops
+    // 2. instantiate AffineLoopNest<true>s; any non-affine loops
     //    are pruned, and their inner loops added as new, separate forests.
     // 3. Existing forests are searched for indirect control flow between
     //    successive loops. In all such cases, the loops at that level are
@@ -325,7 +325,7 @@ class TurboLoopPass : public llvm::PassInfoMixin<TurboLoopPass> {
         llvm::delinearize(*SE, accessFn, subscripts, sizes, elSize);
         assert(subscripts.size() == sizes.size());
         // SHOWLN(sizes.size());
-        AffineLoopNest &aln = loopTrees[loopMap[L]].affineLoop;
+        AffineLoopNest<true> &aln = loopTrees[loopMap[L]].affineLoop;
         if (sizes.size() == 0)
             return ArrayReference(basePointer, &aln, std::move(sizes),
                                   std::move(subscripts), pred);

--- a/test/compat_test.cpp
+++ b/test/compat_test.cpp
@@ -135,7 +135,8 @@ TEST(AffineTest0, BasicAssertions) {
     aff.dump();
     llvm::errs() << "About to run first set of bounds tests\n";
     llvm::errs() << "\nPermuting loops 1 and 2\n";
-    auto affp021{aff.rotate(stringToIntMatrix("[1 0 0; 0 0 1; 0 1 0]"))};
+    AffineLoopNest<false> affp021{
+        aff.rotate(stringToIntMatrix("[1 0 0; 0 0 1; 0 1 0]"))};
     // Now that we've swapped loops 1 and 2, we should have
     // for m in 0:M-1, k in 1:N-1, n in 0:k-1
     affp021.dump();
@@ -166,6 +167,7 @@ TEST(NonUnimodularExperiment, BasicAssertions) {
     aff.dump();
     // -2 - i - j >= 0 -> i + j <= -2
     // but i >= 0 and j >= 0 -> isEmpty()
+    aff.initializeComparator();
     aff.pruneBounds();
     EXPECT_TRUE(aff.isEmpty());
 

--- a/test/compat_test.cpp
+++ b/test/compat_test.cpp
@@ -37,7 +37,7 @@ TEST(TrivialPruneBounds, BasicAssertions) {
     auto A{stringToIntMatrix("[0 1 0; -1 1 -1; 0 0 1; -2 1 -1; 1 0 1]")};
     TestLoopFunction tlf;
     tlf.addLoop(std::move(A), 1);
-    AffineLoopNest &aff = tlf.alns[0];
+    AffineLoopNest<true> &aff = tlf.alns[0];
     aff.pruneBounds();
     llvm::errs() << aff << "\n";
     SHOWLN(aff.A);
@@ -57,7 +57,7 @@ TEST(TrivialPruneBounds2, BasicAssertions) {
         "[-1 0 0 0 1 0; -1 1 0 0 0 0; -1 0 1 0 -1 0; -1 0 1 0 0 0]")};
     TestLoopFunction tlf;
     tlf.addLoop(std::move(A), 2);
-    AffineLoopNest &aff = tlf.alns[0];
+    AffineLoopNest<true> &aff = tlf.alns[0];
     aff.pruneBounds();
     aff.dump();
     SHOWLN(aff.A);
@@ -82,7 +82,7 @@ TEST(LessTrivialPruneBounds, BasicAssertions) {
 
     TestLoopFunction tlf;
     tlf.addLoop(std::move(A), 3);
-    AffineLoopNest &aff = tlf.alns[0];
+    AffineLoopNest<true> &aff = tlf.alns[0];
 
     aff.pruneBounds();
     llvm::errs() << "LessTrival test Bounds pruned:\n";
@@ -119,7 +119,7 @@ TEST(AffineTest0, BasicAssertions) {
     TestLoopFunction tlf;
     llvm::errs() << "About to construct affine obj\n";
     tlf.addLoop(std::move(A), 3);
-    AffineLoopNest &aff = tlf.alns[0];
+    AffineLoopNest<true> &aff = tlf.alns[0];
     aff.pruneBounds();
     EXPECT_EQ(aff.A.numRow(), 3);
 
@@ -161,11 +161,12 @@ TEST(NonUnimodularExperiment, BasicAssertions) {
                                   " 0 1 0 0]")};
     TestLoopFunction tlf;
     tlf.addLoop(std::move(A), 2);
-    AffineLoopNest &aff = tlf.alns.back();
+    AffineLoopNest<true> &aff = tlf.alns.back();
     llvm::errs() << "Original order:\n";
     aff.dump();
     // -2 - i - j >= 0 -> i + j <= -2
     // but i >= 0 and j >= 0 -> isEmpty()
+    aff.pruneBounds();
     EXPECT_TRUE(aff.isEmpty());
 
     A = stringToIntMatrix("[0 2 1 -1; "
@@ -174,11 +175,10 @@ TEST(NonUnimodularExperiment, BasicAssertions) {
                           "8 0 -1 -1; "
                           " 0 1 0 0]");
     tlf.addLoop(std::move(A), 2);
-    AffineLoopNest &aff2 = tlf.alns.back();
+    AffineLoopNest<true> &aff2 = tlf.alns.back();
     EXPECT_FALSE(aff2.isEmpty());
 
-    UnboundedAffineLoopNest affp10{
-        aff2.rotate(stringToIntMatrix("[0 1; 1 0]"))};
+    AffineLoopNest<false> affp10{aff2.rotate(stringToIntMatrix("[0 1; 1 0]"))};
     llvm::errs() << "Swapped order:\n";
     affp10.dump();
 

--- a/test/cost_modeling_test.cpp
+++ b/test/cost_modeling_test.cpp
@@ -41,13 +41,13 @@ TEST(TriangularExampleTest, BasicAssertions) {
     TestLoopFunction tlf;
     tlf.addLoop(std::move(AMN), 2);
     tlf.addLoop(std::move(AMNK), 3);
-    AffineLoopNest &loopMN = tlf.alns[0];
+    AffineLoopNest<true> &loopMN = tlf.alns[0];
     EXPECT_FALSE(loopMN.isEmpty());
-    AffineLoopNest &loopMNK = tlf.alns[1];
+    AffineLoopNest<true> &loopMNK = tlf.alns[1];
     EXPECT_FALSE(loopMNK.isEmpty());
-    EXPECT_EQ(loopMN.symbols.size(), loopMNK.symbols.size());
-    for (size_t i = 0; i < loopMN.symbols.size(); ++i)
-        EXPECT_EQ(loopMN.symbols[i], loopMNK.symbols[i]);
+    EXPECT_EQ(loopMN.S.size(), loopMNK.S.size());
+    for (size_t i = 0; i < loopMN.S.size(); ++i)
+        EXPECT_EQ(loopMN.S[i], loopMNK.S[i]);
 
     llvm::ScalarEvolution &SE{tlf.SE};
     auto &builder = tlf.builder;
@@ -59,8 +59,8 @@ TEST(TriangularExampleTest, BasicAssertions) {
     llvm::Value *ptrA = tlf.createArray();
     llvm::Value *ptrU = tlf.createArray();
 
-    const llvm::SCEV *M = loopMN.symbols[0];
-    const llvm::SCEV *N = loopMN.symbols[1];
+    const llvm::SCEV *M = loopMN.S[0];
+    const llvm::SCEV *N = loopMN.S[1];
     llvm::Value *zero = builder.getInt64(0);
     llvm::Value *one = builder.getInt64(1);
     llvm::Value *mv = builder.CreateAdd(zero, one);
@@ -521,9 +521,9 @@ TEST(MeanStDevTest0, BasicAssertions) {
                                               "-1 1 0 -1 0; "
                                               "0 0 0 1 0]")};
     tlf.addLoop(std::move(TwoLoopsMatJI), 2);
-    AffineLoopNest &loopJI = tlf.alns[0];
-    AffineLoopNest &loopI = tlf.alns[1];
-    AffineLoopNest &loopIJ = tlf.alns[2];
+    AffineLoopNest<true> &loopJI = tlf.alns[0];
+    AffineLoopNest<true> &loopI = tlf.alns[1];
+    AffineLoopNest<true> &loopIJ = tlf.alns[2];
 
     llvm::IRBuilder<> &builder = tlf.builder;
 
@@ -537,8 +537,8 @@ TEST(MeanStDevTest0, BasicAssertions) {
     auto scevS = tlf.getSCEVUnknown(ptrS);
 
     // llvm::ConstantInt *Iv = builder.getInt64(200);
-    const llvm::SCEV *I = loopJI.symbols[0];
-    const llvm::SCEV *J = loopJI.symbols[1];
+    const llvm::SCEV *I = loopJI.S[0];
+    const llvm::SCEV *J = loopJI.S[1];
     llvm::Value *Iv = llvm::dyn_cast<llvm::SCEVUnknown>(I)->getValue();
     llvm::Value *Jv = llvm::dyn_cast<llvm::SCEVUnknown>(J)->getValue();
     auto Jfp = builder.CreateUIToFP(Jv, Float64);
@@ -936,16 +936,16 @@ TEST(DoubleDependenceTest, BasicAssertions) {
                                       "-2 0 1 -1 0; "
                                       "0 0 0 1 0]")};
     tlf.addLoop(std::move(Aloop), 2);
-    AffineLoopNest &loop = tlf.alns.front();
+    AffineLoopNest<true> &loop = tlf.alns.front();
 
     // create arrays
     llvm::Type *Float64 = builder.getDoubleTy();
     llvm::Value *ptrA = tlf.createArray();
     auto scevA = tlf.getSCEVUnknown(ptrA);
 
-    const llvm::SCEV *I = loop.symbols[0];
+    const llvm::SCEV *I = loop.S[0];
     llvm::Value *Iv = llvm::dyn_cast<llvm::SCEVUnknown>(I)->getValue();
-    // llvm::Value* J = loop.symbols[1];
+    // llvm::Value* J = loop.S[1];
     auto zero = builder.getInt64(0);
     auto one = builder.getInt64(1);
     llvm::Value *iv = builder.CreateAdd(zero, one);
@@ -1151,7 +1151,7 @@ TEST(ConvReversePass, BasicAssertions) {
                                       "-1 0 0 1 0 -1 0 0 0; "
                                       "0 0 0 0 0 1 0 0 0]")};
     tlf.addLoop(std::move(Aloop), 4);
-    AffineLoopNest &loop = tlf.alns.front();
+    AffineLoopNest<true> &loop = tlf.alns.front();
 
     // create arrays
     llvm::Type *Float64 = builder.getDoubleTy();
@@ -1163,8 +1163,8 @@ TEST(ConvReversePass, BasicAssertions) {
     auto scevC = tlf.getSCEVUnknown(ptrC);
 
     // llvm::ConstantInt *Jv = builder.getInt64(100);
-    const llvm::SCEV *I = loop.symbols[3];
-    const llvm::SCEV *M = loop.symbols[1];
+    const llvm::SCEV *I = loop.S[3];
+    const llvm::SCEV *M = loop.S[1];
     llvm::Value *Iv = llvm::dyn_cast<llvm::SCEVUnknown>(I)->getValue();
     llvm::Value *Mv = llvm::dyn_cast<llvm::SCEVUnknown>(M)->getValue();
     // llvm::ConstantInt *Nv = builder.getInt64(400);

--- a/test/cost_modeling_test.cpp
+++ b/test/cost_modeling_test.cpp
@@ -1043,9 +1043,9 @@ TEST(DoubleDependenceTest, BasicAssertions) {
     dep0.pruneBounds();
     llvm::errs() << "Dep0 = \n" << dep0 << "\n";
 
-    EXPECT_EQ(dep0.getNumInequalityConstraints(), 4);
+    EXPECT_EQ(dep0.getNumInequalityConstraints(), 2);
     EXPECT_EQ(dep0.getNumEqualityConstraints(), 2);
-    assert(dep0.getNumInequalityConstraints() == 4);
+    assert(dep0.getNumInequalityConstraints() == 2);
     assert(dep0.getNumEqualityConstraints() == 2);
 
     llvm::SmallVector<unsigned, 8> schLoad1(2 + 1);
@@ -1055,9 +1055,9 @@ TEST(DoubleDependenceTest, BasicAssertions) {
     EXPECT_FALSE(dep1.isEmpty());
     dep1.pruneBounds();
     llvm::errs() << "Dep1 = \n" << dep1 << "\n";
-    EXPECT_EQ(dep1.getNumInequalityConstraints(), 4);
+    EXPECT_EQ(dep1.getNumInequalityConstraints(), 2);
     EXPECT_EQ(dep1.getNumEqualityConstraints(), 2);
-    assert(dep1.getNumInequalityConstraints() == 4);
+    assert(dep1.getNumInequalityConstraints() == 2);
     assert(dep1.getNumEqualityConstraints() == 2);
     // MemoryAccess mtgt1{Atgt1,nullptr,schLoad,true};
     llvm::SmallVector<Dependence, 1> dc;

--- a/test/cost_modeling_test.cpp
+++ b/test/cost_modeling_test.cpp
@@ -1043,9 +1043,9 @@ TEST(DoubleDependenceTest, BasicAssertions) {
     dep0.pruneBounds();
     llvm::errs() << "Dep0 = \n" << dep0 << "\n";
 
-    EXPECT_EQ(dep0.getNumInequalityConstraints(), 2);
+    EXPECT_EQ(dep0.getNumInequalityConstraints(), 4);
     EXPECT_EQ(dep0.getNumEqualityConstraints(), 2);
-    assert(dep0.getNumInequalityConstraints() == 2);
+    assert(dep0.getNumInequalityConstraints() == 4);
     assert(dep0.getNumEqualityConstraints() == 2);
 
     llvm::SmallVector<unsigned, 8> schLoad1(2 + 1);
@@ -1055,9 +1055,9 @@ TEST(DoubleDependenceTest, BasicAssertions) {
     EXPECT_FALSE(dep1.isEmpty());
     dep1.pruneBounds();
     llvm::errs() << "Dep1 = \n" << dep1 << "\n";
-    EXPECT_EQ(dep1.getNumInequalityConstraints(), 2);
+    EXPECT_EQ(dep1.getNumInequalityConstraints(), 4);
     EXPECT_EQ(dep1.getNumEqualityConstraints(), 2);
-    assert(dep1.getNumInequalityConstraints() == 2);
+    assert(dep1.getNumInequalityConstraints() == 4);
     assert(dep1.getNumEqualityConstraints() == 2);
     // MemoryAccess mtgt1{Atgt1,nullptr,schLoad,true};
     llvm::SmallVector<Dependence, 1> dc;

--- a/test/dependence_test.cpp
+++ b/test/dependence_test.cpp
@@ -87,9 +87,9 @@ TEST(DependenceTest, BasicAssertions) {
     dep0.pruneBounds();
     llvm::errs() << "Dep0 = \n" << dep0 << "\n";
 
-    EXPECT_EQ(dep0.getNumInequalityConstraints(), 4);
+    EXPECT_EQ(dep0.getNumInequalityConstraints(), 2);
     EXPECT_EQ(dep0.getNumEqualityConstraints(), 2);
-    assert(dep0.getNumInequalityConstraints() == 4);
+    assert(dep0.getNumInequalityConstraints() == 2);
     assert(dep0.getNumEqualityConstraints() == 2);
 
     llvm::SmallVector<unsigned, 8> schLoad1(3);
@@ -99,9 +99,9 @@ TEST(DependenceTest, BasicAssertions) {
     EXPECT_FALSE(dep1.isEmpty());
     dep1.pruneBounds();
     llvm::errs() << "Dep1 = \n" << dep1 << "\n";
-    EXPECT_EQ(dep1.getNumInequalityConstraints(), 4);
+    EXPECT_EQ(dep1.getNumInequalityConstraints(), 2);
     EXPECT_EQ(dep1.getNumEqualityConstraints(), 2);
-    assert(dep1.getNumInequalityConstraints() == 4);
+    assert(dep1.getNumInequalityConstraints() == 2);
     assert(dep1.getNumEqualityConstraints() == 2);
     // MemoryAccess mtgt1{Atgt1,nullptr,schLoad,true};
     llvm::SmallVector<Dependence, 1> dc;

--- a/test/dependence_test.cpp
+++ b/test/dependence_test.cpp
@@ -87,9 +87,9 @@ TEST(DependenceTest, BasicAssertions) {
     dep0.pruneBounds();
     llvm::errs() << "Dep0 = \n" << dep0 << "\n";
 
-    EXPECT_EQ(dep0.getNumInequalityConstraints(), 2);
+    EXPECT_EQ(dep0.getNumInequalityConstraints(), 4);
     EXPECT_EQ(dep0.getNumEqualityConstraints(), 2);
-    assert(dep0.getNumInequalityConstraints() == 2);
+    assert(dep0.getNumInequalityConstraints() == 4);
     assert(dep0.getNumEqualityConstraints() == 2);
 
     llvm::SmallVector<unsigned, 8> schLoad1(3);
@@ -99,9 +99,9 @@ TEST(DependenceTest, BasicAssertions) {
     EXPECT_FALSE(dep1.isEmpty());
     dep1.pruneBounds();
     llvm::errs() << "Dep1 = \n" << dep1 << "\n";
-    EXPECT_EQ(dep1.getNumInequalityConstraints(), 2);
+    EXPECT_EQ(dep1.getNumInequalityConstraints(), 4);
     EXPECT_EQ(dep1.getNumEqualityConstraints(), 2);
-    assert(dep1.getNumInequalityConstraints() == 2);
+    assert(dep1.getNumInequalityConstraints() == 4);
     assert(dep1.getNumEqualityConstraints() == 2);
     // MemoryAccess mtgt1{Atgt1,nullptr,schLoad,true};
     llvm::SmallVector<Dependence, 1> dc;


### PR DESCRIPTION
On commit 0f46ae6d:
```
10/14 dependence_test                 OK              0.31s
11/14 simplex_test                    OK              0.32s
12/14 normal_form_test                OK              0.52s
13/14 linear_diophantine_test         OK              0.86s
14/14 cost_modeling_test              OK              2.03s
```
While on the latest commit 5cd1455:
```
10/14 simplex_test                    OK              0.33s
11/14 normal_form_test                OK              0.53s
12/14 dependence_test                 OK              0.65s
13/14 linear_diophantine_test         OK              0.86s
14/14 cost_modeling_test              OK              3.29s
```
Which is a rather hefty performance regression for both the dependence test and the cost modeling test, especially given that this was supposed to (ideally) make things lighter.

A likely culprit is that the satisfaction and bounding simplices are larger, as we add all implicit lower bounds, while the explicit version of the code pruned them.
I'll try doing some pruning.