### PR TITLE
Get it compiling under gcc again

### DIFF
--- a/include/BitSets.hpp
+++ b/include/BitSets.hpp
@@ -91,7 +91,7 @@ struct BitSet {
     };
     // BitSet::Iterator(std::vector<std::uint64_t> &seta)
     //     : set(seta), didx(0), offset(0), state(seta[0]), count(0) {};
-    constexpr Iterator begin() const {
+    inline Iterator begin() const {
         auto b{data.begin()};
         auto e{data.end()};
         if (b == e)
@@ -100,7 +100,7 @@ struct BitSet {
         return ++it;
     }
     constexpr static Iterator::End end() { return Iterator::End{}; };
-    constexpr size_t front() const {
+    inline size_t front() const {
         for (size_t i = 0; i < data.size(); ++i)
             if (data[i])
                 return 64 * i + std::countr_zero(data[i]);

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 // Demonstrate some basic assertions.
-TEST(HelloTest, BasicAssertions) {
+TEST(SparseIndexingTest, BasicAssertions) {
     SmallSparseMatrix<int64_t> Asparse(3, 4);
     llvm::errs() << "&Asparse = " << &Asparse << "\n";
     Asparse(0, 1) = 5;

--- a/test/normal_form_test.cpp
+++ b/test/normal_form_test.cpp
@@ -47,8 +47,8 @@ TEST(OrthogonalizeTest, BasicAssertions) {
             printVector(llvm::errs() << "included = ", included) << "\n";
             if (auto optlu = LU::fact(K)) {
                 SHOWLN(K);
-                if (auto optA2 = optlu.getValue().inv()) {
-                    SquareMatrix<Rational> &A2 = optA2.getValue();
+                if (auto optA2 = (*optlu).inv()) {
+                    SquareMatrix<Rational> &A2 = *optA2;
                     SHOWLN(A2);
                     SHOWLN(B);
 


### PR DESCRIPTION
GCC appears to be stricter w/ respect to constexpr than Clang, prompting a switch to `std::optional` over `llvm::Optional`