### PR TITLE
Start adding remarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         sudo chmod +x llvm.sh
         sudo ./llvm.sh 15 all
         sudo apt install g++ libgtest-dev ninja-build pkg-config cmake
+        sudo ln -s $(which opt-15) /usr/local/bin/opt
         # ln -s /usr/bin/llvm-config-15 ~/.local/bin/llvm-config
     - run: meson setup builddirgcc -Db_santize=address,undefined -Db_coverage=true
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - run: brew install gcc llvm@15 ninja pkg-config cmake
     - run: pip install meson ninja gcovr
     - run: echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
-    - run: meson setup builddir/
+    - run: meson setup builddir -Db_santize=address,undefined -Db_coverage=true -Dtestremarks=false
       env:
         CXX: g++-12
         CXXFLAGS: "-stdlib=libstdc++"

--- a/include/ArrayReference.hpp
+++ b/include/ArrayReference.hpp
@@ -204,7 +204,8 @@ struct ArrayReference {
     return os << "]";
   }
   // use gcd to check if they're known to be independent
-  [[nodiscard]] auto gcdKnownIndependent(const ArrayReference &) const -> bool {
+  [[nodiscard]] constexpr static auto
+  gcdKnownIndependent(const ArrayReference &) -> bool {
     // TODO: handle this!
     // consider `x[2i]` vs `x[2i + 1]`, the former
     // will have a stride of `2`, and the latter of `x[2i+1]`

--- a/include/ArrayReference.hpp
+++ b/include/ArrayReference.hpp
@@ -148,15 +148,12 @@ struct ArrayReference {
 
   friend auto operator<<(llvm::raw_ostream &os, const ArrayReference &ar)
     -> llvm::raw_ostream & {
-    SHOWLN(ar.indexMatrix());
     os << "ArrayReference " << *ar.basePointer << " (dim = " << ar.getArrayDim()
        << ", num loops: " << ar.getNumLoops();
     if (ar.sizes.size())
       os << ", element size: " << *ar.sizes.back();
     os << "):\n";
     PtrMatrix<int64_t> A{ar.indexMatrix()};
-    SHOW(A.numRow());
-    CSHOWLN(A.numCol());
     os << "Sizes: [";
     if (ar.sizes.size()) {
       os << " unknown";

--- a/include/DependencyPolyhedra.hpp
+++ b/include/DependencyPolyhedra.hpp
@@ -1233,9 +1233,9 @@ struct Dependence {
       os << "x -> y:";
     else
       os << "y -> x:";
-    os << d.depPoly << "\nA = " << d.depPoly.A << "\nE = " << d.depPoly.E
-       << "\nSchedule Constraints:" << d.dependenceSatisfaction
-       << "\nBounding Constraints:" << d.dependenceBounding;
+    // os << d.depPoly << "\nA = " << d.depPoly.A << "\nE = " << d.depPoly.E
+    //    << "\nSchedule Constraints:" << d.dependenceSatisfaction
+    //    << "\nBounding Constraints:" << d.dependenceBounding;
     if (d.in)
       os << "\n\tInput:\n" << *d.in;
     if (d.out)

--- a/include/Instruction.hpp
+++ b/include/Instruction.hpp
@@ -1451,9 +1451,7 @@ auto Instruction::Cache::getInstruction(llvm::BumpPtrAllocator &alloc,
   -> Instruction * {
   if (Instruction *i = completeInstruction(alloc, predMap, instr))
     return i;
-  llvm::errs() << "Could not find instruction " << *instr << "\n";
   if (containsCycle(instr)) {
-    llvm::errs() << "Instruction is part of a cycle\n";
     auto *i =
       new (alloc) Instruction(Instruction::Intrinsic(instr), instr->getType());
     llvmToInternalMap[instr] = i;

--- a/include/LoopBlock.hpp
+++ b/include/LoopBlock.hpp
@@ -1315,13 +1315,13 @@ struct LinearProgramLoopBlock {
     }
     // BitSet
     // memNodesWithOutEdges{BitSet::dense(lblock.memory.size())};
-    os << "\nLoopBlock Edges (#edges = " << lblock.edges.size() << "):\n";
+    os << "\nLoopBlock Edges (#edges = " << lblock.edges.size() << "):";
     for (auto &edge : lblock.edges) {
-      os << "\tEdge = " << edge;
+      os << "\n\tEdge = " << edge;
       for (size_t inIndex : edge.in->nodeIndex) {
         const Schedule &sin = lblock.nodes[inIndex].schedule;
-        os << "Schedule In:\nnodeIndex = " << edge.in->nodeIndex
-           << "; ref = " << edge.in->ref << "\ns.getPhi()" << sin.getPhi()
+        os << "Schedule In: nodeIndex = " << edge.in->nodeIndex
+           << "\nref = " << edge.in->ref << "\ns.getPhi()" << sin.getPhi()
            << "\ns.getFusionOmega() = " << sin.getFusionOmega()
            << "\ns.getOffsetOmega() = " << sin.getOffsetOmega();
       }

--- a/include/LoopBlock.hpp
+++ b/include/LoopBlock.hpp
@@ -15,6 +15,7 @@
 #include <iterator>
 #include <limits>
 #include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/User.h>
@@ -644,10 +645,8 @@ struct LinearProgramLoopBlock {
       }
     }
     if (tryOrth) {
-      if (std::optional<BitSet<>> opt = optimize(g, 0, maxDepth)) {
-        llvm::errs() << "orth opt succeeded!\n";
+      if (std::optional<BitSet<>> opt = optimize(g, 0, maxDepth))
         return opt;
-      }
       for (auto &&n : nodes)
         n.rank = 0;
     }
@@ -966,7 +965,7 @@ struct LinearProgramLoopBlock {
       for (auto &s : sol)
         allZero &= (s == 0);
       if (allZero)
-        SHOWLN(omniSimplex);
+        llvm::errs() << "omniSimplex = " << omniSimplex << "\n";
       assert(!allZero);
     }
 #endif
@@ -1018,16 +1017,9 @@ struct LinearProgramLoopBlock {
     }
   }
   [[nodiscard]] static auto lexSign(PtrVector<int64_t> x) -> int64_t {
-    // TODO: once `std::ranges::reverse_view` works on up to date Linux
-    // distros like Arch and Fedora, use a range based for loop. Currently,
-    // applying the automatic fix:
-    // for (int64_t it : std::ranges::reverse_view(x))
-    // won't compile. There is a deduction failure.
-    // Possibly fixable by defining more PtrVector methods.
-    // NOLINTNEXTLINE(modernize-loop-convert)
-    for (auto it = x.rbegin(); it != x.rend(); ++it)
-      if (*it)
-        return 2 * (*it > 0) - 1;
+    for (int64_t it : llvm::reverse(x))
+      if (it)
+        return 2 * (it > 0) - 1;
     return 0;
   }
   void addIndependentSolutionConstraints(const Graph &g, size_t depth) {
@@ -1108,24 +1100,6 @@ struct LinearProgramLoopBlock {
       node.schedule.getOffsetOmega()(depth) = 0;
       MutSquarePtrMatrix<int64_t> phi = node.schedule.getPhi();
       phi(depth, _) = std::numeric_limits<int64_t>::min();
-      // llvm::SmallVector<uint64_t> indexMasks;
-      // if (depth) {
-      //     A = phi(_(0, depth), _).transpose();
-      //     NormalForm::nullSpace11(N, A);
-      //     // we check array references to see if we can find one index
-      //     // uint64_t nullMask = nonZeroMask(N);
-      //     // for (MemoryAccess *mem : g.mem){
-      //     //     nonZeroMasks(indexMasks,
-      //     //     mem->ref.indexMatrix().transpose());
-
-      //     // }
-      //     phi(depth, _) = N(0, _) * lexSign(N(0, _));
-      //     llvm::errs() << "Set schedules independent:\n";
-      //     SHOWLN(phi(depth, _));
-      // } else {
-      //     phi(depth, _(begin, end - 1)) = 0;
-      //     phi(depth, end) = 1;
-      // }
     }
   }
   void resetPhiOffsets() {
@@ -1215,32 +1189,6 @@ struct LinearProgramLoopBlock {
     // remove
     return satDeps;
   }
-  //     void lexMinimize(const Graph &g, Vector<Rational> &sol,
-  //     size_t depth){
-  // 	// omniSimplex.lexMinimize(sol);
-  // #ifndef NDEBUG
-  //         assert(omniSimplex.inCanonicalForm);
-  //         omniSimplex.assertCanonical();
-  //         // SHOWLN(omniSimplex);
-  // #endif
-  //         for (size_t v = 0; v < numActiveEdges + numBounding;)
-  //             omniSimplex.lexMinimize(++v);
-  // 	for (auto &&node : nodes) {
-  //             if (depth >= node.getNumLoops())
-  //                 continue;
-  //             if (!hasActiveEdges(g, node))
-  // 		continue;
-  // 	    omniSimplex.lexMinimize(node.getPhiOffset());
-  // 	}
-  // 	for (auto &&node : nodes) {
-  //             if (depth >= node.getNumLoops())
-  //                 continue;
-  //             if (!hasActiveEdges(g, node))
-  // 		continue;
-  // 	    omniSimplex.lexMinimize(node.omegaOffset);
-  // 	}
-  //         omniSimplex.copySolution(sol);
-  //     }
   [[nodiscard]] auto optimizeLevel(Graph &g, size_t d)
     -> std::optional<BitSet<>> {
     if (numPhiCoefs == 0) {

--- a/include/Loops.hpp
+++ b/include/Loops.hpp
@@ -6,6 +6,7 @@
 #include "./Math.hpp"
 #include "./Polyhedra.hpp"
 #include "./Utilities.hpp"
+#include "RemarkAnalysis.hpp"
 #include <bit>
 #include <cstddef>
 #include <cstdint>
@@ -14,6 +15,7 @@
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Analysis/LoopInfo.h>
+#include <llvm/Analysis/OptimizationRemarkEmitter.h>
 #include <llvm/Analysis/ScalarEvolution.h>
 #include <llvm/Analysis/ScalarEvolutionExpressions.h>
 #include <llvm/IR/Constant.h>
@@ -264,9 +266,6 @@ struct AffineLoopNest
     }
     ret.initializeComparator();
     ret.pruneBounds();
-    // llvm::errs() << "A = \n" << A << "\n";
-    // llvm::errs() << "R = \n" << R << "\n";
-    // llvm::errs() << "B = \n" << B << "\n";
     return ret;
   }
 
@@ -288,27 +287,6 @@ struct AffineLoopNest
     } else if (const auto *ex = llvm::dyn_cast<const llvm::SCEVAddExpr>(v)) {
       const llvm::SCEV *op0 = ex->getOperand(0);
       const llvm::SCEV *op1 = ex->getOperand(1);
-      // // check if either op is a SCEVMinMaxExpr of the wrong kind
-      // // if so, check if we can simplify by moving the add inside.
-      // if (const llvm::SCEVAddRecExpr *ar0 =
-      //         llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
-      //     if (const llvm::SCEVMinMaxExpr *mm1 =
-      //             llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(op1)) {
-      //         llvm::errs() << "for SCEV:" << *ex << "\nwe
-      //         distribute:\n"
-      //                      << *SE.getAddExpr(ar0, mm1->getOperand(0),
-      //                                        llvm::SCEV::NoWrapMask)
-      //                      << "\n"
-      //                      << *SE.getAddExpr(ar0, mm1->getOperand(1),
-      //                                        llvm::SCEV::NoWrapMask)
-      //                      << "\n";
-      //     }
-      // } else if (const llvm::SCEVMinMaxExpr *mm0 =
-      //                llvm::dyn_cast<const llvm::SCEVMinMaxExpr>(op0)) {
-      //     if (const llvm::SCEVAddRecExpr *ar1 =
-      //             llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
-      //     }
-      // }
       Row M = A.numRow();
       minDepth = addSymbol(B, L, op0, SE, lu, mlt, minDepth);
       if (M != A.numRow())
@@ -346,8 +324,6 @@ struct AffineLoopNest
         return addSymbol(B, L, S, SE, lu, mlt, minDepth);
       bool isMin =
         llvm::isa<llvm::SCEVSMinExpr>(ex) || llvm::isa<llvm::SCEVUMinExpr>(ex);
-      llvm::errs() << "llvm::SCEVMinMaxExpr: " << *ex << "\nisMin = " << isMin
-                   << "; mlt = " << mlt << "\n";
       const llvm::SCEV *op0 = ex->getOperand(0);
       const llvm::SCEV *op1 = ex->getOperand(1);
       if (isMin ^
@@ -382,8 +358,8 @@ struct AffineLoopNest
     return false;
   }
   auto addBackedgeTakenCount(IntMatrix &B, llvm::Loop *L, const llvm::SCEV *BT,
-                             llvm::ScalarEvolution &SE, size_t minDepth)
-    -> size_t {
+                             llvm::ScalarEvolution &SE, size_t minDepth,
+                             llvm::OptimizationRemarkEmitter *ORE) -> size_t {
     Row M = A.numRow();
     A.resize(M + 1);
     B.resize(M + 1);
@@ -400,19 +376,30 @@ struct AffineLoopNest
         // predicates);
         if (const llvm::SCEV *BTP = getBackedgeTakenCount(SE, P)) {
           if (!llvm::isa<llvm::SCEVCouldNotCompute>(BTP))
-            return addBackedgeTakenCount(B, P, BTP, SE, minDepth);
-          else
-            llvm::errs() << "SCEVCouldNotCompute from loop: " << *P << "\n";
+            return addBackedgeTakenCount(B, P, BTP, SE, minDepth, ORE);
+          else if (ORE) {
+            llvm::SmallVector<char, 128> msg;
+            llvm::raw_svector_ostream os(msg);
+            os << "SCEVCouldNotCompute from loop: " << *P << "\n";
+            llvm::OptimizationRemarkAnalysis analysis{
+              remarkAnalysis("AffineLoopConstruction", L)};
+            ORE->emit(analysis << os.str());
+          }
         }
-      } else {
-        llvm::errs() << "Fail because symbols are not loop invariant in loop:\n"
-                     << *P << "\n";
+      } else if (ORE) {
+        llvm::SmallVector<char, 256> msg;
+        llvm::raw_svector_ostream os(msg);
+        os << "Fail because symbols are not loop invariant in loop:\n"
+           << *P << "\n";
         if (auto b = L->getBounds(SE))
-          llvm::errs() << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
-                       << "\nStep: " << *b->getStepValue()
-                       << "\nFinal: " << b->getFinalIVValue() << "\n";
+          os << "Loop Bounds:\nInitial: " << b->getInitialIVValue()
+             << "\nStep: " << *b->getStepValue()
+             << "\nFinal: " << b->getFinalIVValue() << "\n";
         for (auto s : S)
-          llvm::errs() << *s << "\n";
+          os << *s << "\n";
+        llvm::OptimizationRemarkAnalysis analysis{
+          remarkAnalysis("AffineLoopConstruction", L)};
+        ORE->emit(analysis << os.str());
       }
     }
     return std::max(depth - 1, minDepth);
@@ -431,15 +418,15 @@ struct AffineLoopNest
       return {};
     return AffineLoopNest<NonNegative>(L, BT, SE);
   }
-  AffineLoopNest(llvm::Loop *L, const llvm::SCEV *BT,
-                 llvm::ScalarEvolution &SE) {
+  AffineLoopNest(llvm::Loop *L, const llvm::SCEV *BT, llvm::ScalarEvolution &SE,
+                 llvm::OptimizationRemarkEmitter *ORE = nullptr) {
     IntMatrix B;
     // once we're done assembling these, we'll concatenate A and B
     size_t maxDepth = L->getLoopDepth();
     // size_t maxNumSymbols = BT->getExpressionSize();
     A.resize(0, 1, 1 + BT->getExpressionSize());
     B.resize(0, maxDepth, maxDepth);
-    size_t minDepth = addBackedgeTakenCount(B, L, BT, SE, 0);
+    size_t minDepth = addBackedgeTakenCount(B, L, BT, SE, 0, ORE);
     // We first check for loops in B that are shallower than minDepth
     // we include all loops such that L->getLoopDepth() > minDepth
     // note that the outer-most loop has a depth of 1.
@@ -462,8 +449,6 @@ struct AffineLoopNest
           addSymbol(SE.getAddRecExpr(SE.getZero(IntTyp), SE.getOne(IntTyp), P,
                                      llvm::SCEV::NoWrapMask),
                     _(i, i + 1), Bid);
-          llvm::errs() << "UnboundedAffineLoopNest iter i = " << i
-                       << "A = " << A << "\n";
         }
       }
     }
@@ -552,8 +537,10 @@ struct AffineLoopNest
   void addZeroLowerBounds() {
     if (isEmpty())
       return;
-    if constexpr (NonNegative)
+    if constexpr (NonNegative) {
+      initializeComparator();
       return pruneBounds();
+    }
     // return initializeComparator();
     auto [M, N] = A.size();
     if (!N)
@@ -585,6 +572,7 @@ struct AffineLoopNest
       fourierMotzkinNonNegative(A, i + getNumSymbols());
     else
       fourierMotzkin(A, i + getNumSymbols());
+    initializeComparator();
     pruneBounds();
   }
   [[nodiscard]] auto removeLoop(size_t i) const -> AffineLoopNest<NonNegative> {
@@ -739,16 +727,20 @@ struct AffineLoopNest
     const size_t numVar = getNumLoops();
     const size_t numVarMinus1 = numVar - 1;
     const size_t numConst = getNumSymbols();
+    bool hasPrintedLine = false;
     for (size_t j = 0; j < A.numRow(); ++j) {
       int64_t Aji = A(j, i + numConst) * sign;
       if (Aji <= 0)
         continue;
-      if (A(j, i + numConst) != sign) {
+      if (hasPrintedLine)
+        for (size_t k = 0; k < 21; ++k)
+          os << ' ';
+      hasPrintedLine = true;
+      if (A(j, i + numConst) != sign)
         os << Aji << "*i_" << numVarMinus1 - i
            << ((sign < 0) ? " <= " : " >= ");
-      } else {
+      else
         os << "i_" << numVarMinus1 - i << ((sign < 0) ? " <= " : " >= ");
-      }
       PtrVector<int64_t> b = getProgVars(j);
       bool printed = !allZero(b);
       if (printed)
@@ -788,9 +780,9 @@ struct AffineLoopNest
     size_t numLoopsMinus1 = aln.getNumLoops() - 1;
     size_t i = 0;
     while (true) {
-      os << "Loop " << numLoopsMinus1 - i << " lower bounds:\n";
+      os << "Loop " << numLoopsMinus1 - i << " lower bounds: ";
       aln.printLowerBound(os, i);
-      os << "Loop " << numLoopsMinus1 - i << " upper bounds:\n";
+      os << "Loop " << numLoopsMinus1 - i << " upper bounds: ";
       aln.printUpperBound(os, i);
       if (i == numLoopsMinus1)
         break;
@@ -798,5 +790,5 @@ struct AffineLoopNest
     }
     return os;
   }
-  void dump() const { llvm::errs() << *this; }
+  void dump(llvm::raw_ostream &os = llvm::errs()) const { os << *this; }
 };

--- a/include/Loops.hpp
+++ b/include/Loops.hpp
@@ -3,7 +3,6 @@
 #include "./Comparators.hpp"
 #include "./Constraints.hpp"
 #include "./EmptyArrays.hpp"
-#include "./Macro.hpp"
 #include "./Math.hpp"
 #include "./Polyhedra.hpp"
 #include "./Utilities.hpp"
@@ -365,72 +364,17 @@ struct AffineLoopNest
         return addSymbol(B, L, op1, SE, lu, mlt, minDepth);
       } else if (addRecMatchesLoop(op1, L)) {
         return addSymbol(B, L, op0, SE, lu, mlt, minDepth);
-        // } else {
-        //     // auto S = simplifyMinMax(SE, ex);
-        //     // if (S != v)
-        //     //     return addSymbol(B,L,S,SE,l,u,mlt,minDepth);
-        //     // llvm::errs() << "Failing on llvm::SCEVMinMaxExpr = "
-        //     << *ex
-        //     //              << "<<\n*L =" << *L << "\n";
-        //     // SHOWLN(*op0);
-        //     // SHOWLN(*op1);
-        //     // TODO: don't only consider final value
-        //     // this assumes the final value is the maximum, which is
-        //     not
-        //     // necessarilly true
-        //     if (auto op0ar =
-        //     llvm::dyn_cast<llvm::SCEVAddRecExpr>(op0)) {
-        //         // auto op0final = SE.getSCEVAtScope(
-        //         //     op0ar, op0ar->getLoop()->getParentLoop());
-        //         auto op0final = SE.getSCEVAtScope(op0ar, nullptr);
-        //         SHOWLN(*op0final);
-        //         auto op0FinalMinusOp1 = SE.getMinusSCEV(op0final,
-        //         op1);
-        //         SHOWLN(SE.isKnownNonNegative(op0FinalMinusOp1));
-        //         SHOWLN(SE.isKnownNonPositive(op0FinalMinusOp1));
-        //         auto op0init = op0ar->getOperand(0);
-        //         auto op0InitMinusOp1 = SE.getMinusSCEV(op0init, op1);
-        //         SHOWLN(SE.isKnownNonNegative(op0InitMinusOp1));
-        //         SHOWLN(SE.isKnownNonPositive(op0InitMinusOp1));
-        //         auto op0step = op0ar->getOperand(0);
-        //         SHOWLN(SE.isKnownNonNegative(op0step));
-        //         SHOWLN(SE.isKnownNonPositive(op0step));
-        //     }
-        //     if (auto op1ar =
-        //     llvm::dyn_cast<llvm::SCEVAddRecExpr>(op1)) {
-        //         SHOWLN(*SE.getSCEVAtScope(
-        //             op1ar, op1ar->getLoop()->getParentLoop()));
-        //     }
-        //     auto op0MinusOp1 = SE.getMinusSCEV(op0, op1);
-        //     // SHOWLN(SE.isKnownNonNegative(op0MinusOp1));
-        //     // SHOWLN(SE.isKnownNonPositive(op0MinusOp1));
-
-        //     if (auto b = L->getBounds(SE))
-        //         llvm::errs()
-        //             << "Loop Bounds:\nInitial: " <<
-        //             b->getInitialIVValue()
-        //             << "\nStep: " << *b->getStepValue()
-        //             << "\nFinal: " << b->getFinalIVValue() << "\n";
-        //     assert(false);
       }
     } else if (const auto *ex = llvm::dyn_cast<llvm::SCEVCastExpr>(v))
       return addSymbol(B, L, ex->getOperand(0), SE, lu, mlt, minDepth);
-    // } else if (const llvm::SCEVUDivExpr *ex = llvm::dyn_cast<const
-    // llvm::SCEVUDivExpr>(v)) {
-
-    // } else if (const llvm::SCEVUnknown *ex = llvm::dyn_cast<const
-    // llvm::SCEVUnknown>(v)) {
     addSymbol(v, lu, mlt);
     return minDepth;
   }
   void addSymbol(const llvm::SCEV *v, Range<size_t, size_t> lu, int64_t mlt) {
     assert(lu.size());
-    // llvm::errs() << "Before adding sym A = " << A << "\n";
     S.push_back(v);
     A.resize(A.numCol() + 1);
-    // A.insertZeroColumn(symbols.size());
     A(lu, S.size()) = mlt;
-    // llvm::errs() << "After adding sym A = " << A << "\n";
   }
   static auto addRecMatchesLoop(const llvm::SCEV *S, llvm::Loop *L) -> bool {
     if (const auto *x = llvm::dyn_cast<const llvm::SCEVAddRecExpr>(S))
@@ -443,12 +387,7 @@ struct AffineLoopNest
     Row M = A.numRow();
     A.resize(M + 1);
     B.resize(M + 1);
-    llvm::errs() << "BT = " << *BT
-                 << "\naddBackedgeTakenCount pre addSym; M = " << M
-                 << "; A = " << A << "\n";
     minDepth = addSymbol(B, L, BT, SE, _(M, M + 1), 1, minDepth);
-    llvm::errs() << "addBackedgeTakenCount post addSym; M = " << M
-                 << "; A = " << A << "\n";
     assert(A.numRow() == B.numRow());
     size_t depth = L->getLoopDepth();
     for (auto m = size_t(M); m < A.numRow(); ++m)
@@ -460,7 +399,6 @@ struct AffineLoopNest
         // auto *BTI = SE.getPredicatedBackedgeTakenCount(L,
         // predicates);
         if (const llvm::SCEV *BTP = getBackedgeTakenCount(SE, P)) {
-          llvm::errs() << "BackedgeTakenCount: " << *BTP << "\n";
           if (!llvm::isa<llvm::SCEVCouldNotCompute>(BTP))
             return addBackedgeTakenCount(B, P, BTP, SE, minDepth);
           else
@@ -848,9 +786,6 @@ struct AffineLoopNest
     -> llvm::raw_ostream & {
     AffineLoopNest<NonNegative> aln{alnb};
     size_t numLoopsMinus1 = aln.getNumLoops() - 1;
-    SHOWLN(alnb.getNumLoops());
-    SHOWLN(aln.getNumLoops());
-    SHOWLN(alnb.A);
     size_t i = 0;
     while (true) {
       os << "Loop " << numLoopsMinus1 - i << " lower bounds:\n";

--- a/include/Macro.hpp
+++ b/include/Macro.hpp
@@ -1,6 +1,0 @@
-#pragma once
-
-#define SHOW(ex) llvm::errs() << #ex << " = " << ex;
-#define CSHOW(ex) llvm::errs() << "; " << #ex << " = " << ex;
-#define SHOWLN(ex) llvm::errs() << #ex << " = " << ex << "\n";
-#define CSHOWLN(ex) llvm::errs() << "; " << #ex << " = " << ex << "\n";

--- a/include/MemoryAccess.hpp
+++ b/include/MemoryAccess.hpp
@@ -106,6 +106,7 @@ auto operator<<(llvm::raw_ostream &os, const MemoryAccess &m)
     os << *instr;
   os << "\n"
      << m.ref << "\nSchedule Omega: " << m.getFusionOmega()
-     << "\nAffineLoopNest: " << *m.ref.loop;
+     << "\nAffineLoopNest:\n"
+     << *m.ref.loop;
   return os;
 }

--- a/include/NormalForm.hpp
+++ b/include/NormalForm.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "./EmptyArrays.hpp"
 #include "./GreatestCommonDivisor.hpp"
-#include "./Macro.hpp"
 #include "./Math.hpp"
 #include "./Utilities.hpp"
 #include <concepts>
@@ -161,7 +160,6 @@ static inline auto pivotRows(MutPtrMatrix<int64_t> A, Col i, Row M, Row piv)
   llvm::SmallVector<unsigned> included;
   included.reserve(std::min(size_t(M), size_t(N)));
   for (size_t i = 0, j = 0; i < std::min(size_t(M), size_t(N)); ++j) {
-    SHOWLN(A);
     // zero ith row
     if (pivotRows(A, K, i, M)) {
       // cannot pivot, this is a linear combination of previous
@@ -170,9 +168,6 @@ static inline auto pivotRows(MutPtrMatrix<int64_t> A, Col i, Row M, Row piv)
     } else {
       zeroSupDiagonal(A, K, i, M, N);
       int64_t Aii = A(i, i);
-      SHOW(Aii);
-      CSHOW(j);
-      CSHOWLN(i);
       if (std::abs(Aii) != 1) {
         // including this row renders the matrix not unimodular!
         // therefore, we drop the row.

--- a/include/Polyhedra.hpp
+++ b/include/Polyhedra.hpp
@@ -5,6 +5,7 @@
 #include "./EmptyArrays.hpp"
 #include "./Math.hpp"
 #include "./NormalForm.hpp"
+#include "VectorGreatestCommonDivisor.hpp"
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -137,6 +138,9 @@ struct Polyhedra {
         }
       }
     }
+    if constexpr (hasEqualities)
+      for (size_t i = 0; i < E.numRow(); ++i)
+        normalizeByGCD(E(i, _));
   }
 
   [[nodiscard]] constexpr auto getNumSymbols() const -> size_t {

--- a/include/RemarkAnalysis.hpp
+++ b/include/RemarkAnalysis.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Analysis/LoopInfo.h>
+#include <llvm/IR/DiagnosticInfo.h>
+[[maybe_unused, nodiscard]] static auto
+remarkAnalysis(const llvm::StringRef remarkName, llvm::Loop *L,
+               llvm::Instruction *I = nullptr)
+  -> llvm::OptimizationRemarkAnalysis {
+  llvm::Value *codeRegion = L->getHeader();
+  llvm::DebugLoc DL = L->getStartLoc();
+
+  if (I) {
+    codeRegion = I->getParent();
+    // If there is no debug location attached to the instruction, revert
+    // back to using the loop's.
+    if (I->getDebugLoc())
+      DL = I->getDebugLoc();
+  }
+
+  return {"turbo-loop", remarkName, DL, codeRegion};
+}

--- a/include/Schedule.hpp
+++ b/include/Schedule.hpp
@@ -58,7 +58,6 @@ struct Schedule {
     numLoops = nLoops;
     data.resize(requiredScheduleStorage(nLoops));
     getPhi().antiDiag() = 1;
-    // getOmega() = 0;
   }
   Schedule() = default;
   Schedule(size_t nLoops) : numLoops(nLoops) {
@@ -67,19 +66,12 @@ struct Schedule {
   };
   Schedule(llvm::ArrayRef<unsigned> omega) : numLoops(omega.size() - 1) {
     data.resize(requiredScheduleStorage(numLoops));
-    // getPhi().antiDiag() = 1;
-    llvm::errs() << "constructing schedule with omega = [" << omega.front();
-    for (size_t i = 1; i < omega.size(); ++i)
-      llvm::errs() << ", " << omega[i];
-    llvm::errs() << "]\n";
     MutPtrVector<int64_t> o{getFusionOmega()};
     for (size_t i = 0; i < omega.size(); ++i)
       o[i] = omega[i];
   }
   void truncate(size_t newNumLoops) {
     if (newNumLoops < numLoops) {
-      // llvm::errs() << "pre truncate: ";
-      // CSHOWLN(getOmega());
       size_t oOffset = getNumLoopsSquared() + size_t(numLoops) - newNumLoops;
       size_t nOffset = newNumLoops * newNumLoops;
       for (size_t i = 0; i < newNumLoops; ++i)
@@ -88,8 +80,6 @@ struct Schedule {
       numLoops = newNumLoops;
     }
     getPhi().antiDiag() = 1;
-    // llvm::errs() << "post truncate: ";
-    // CSHOWLN(getOmega());
   }
   auto getPhi() -> MutSquarePtrMatrix<int64_t> {
     // return MutSquarePtrMatrix<int64_t>(data.data(), numLoops);

--- a/include/TurboLoop.hpp
+++ b/include/TurboLoop.hpp
@@ -7,6 +7,7 @@
 #include "./Loops.hpp"
 #include "./Math.hpp"
 #include "./MemoryAccess.hpp"
+#include "RemarkAnalysis.hpp"
 #include <algorithm>
 #include <bit>
 #include <cassert>
@@ -716,22 +717,6 @@ public:
       fillLoopBlock(*root.subLoops[i]);
   }
 
-  static auto remarkAnalysis(const llvm::StringRef remarkName, llvm::Loop *L,
-                             llvm::Instruction *I = nullptr)
-    -> llvm::OptimizationRemarkAnalysis {
-    llvm::Value *codeRegion = L->getHeader();
-    llvm::DebugLoc DL = L->getStartLoc();
-
-    if (I) {
-      codeRegion = I->getParent();
-      // If there is no debug location attached to the instruction, revert
-      // back to using the loop's.
-      if (I->getDebugLoc())
-        DL = I->getDebugLoc();
-    }
-
-    return {"turbo-loop", remarkName, DL, codeRegion};
-  }
   // https://llvm.org/doxygen/LoopVectorize_8cpp_source.html#l00932
   void remark(const llvm::StringRef remarkName, llvm::Loop *L,
               const llvm::StringRef remarkMessage,

--- a/include/VectorGreatestCommonDivisor.hpp
+++ b/include/VectorGreatestCommonDivisor.hpp
@@ -20,7 +20,6 @@ using LinearAlgebra::PtrVector, LinearAlgebra::MutPtrVector;
     for (size_t n = 2; (n < N) & (g != 1); ++n)
       g = gcd(g, x[n]);
     if (g > 1)
-      for (auto &&a : x)
-        a /= g;
+      x /= g;
   }
 }

--- a/lib/TurboLoop.cpp
+++ b/lib/TurboLoop.cpp
@@ -54,24 +54,8 @@ auto TurboLoopPass::run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM)
   // llvm::LoopNest LA = FAM.getResult<llvm::LoopNestAnalysis>(F);
   // llvm::AssumptionCache &AC = FAM.getResult<llvm::AssumptionAnalysis>(F);
   // llvm::DominatorTree &DT = FAM.getResult<llvm::DominatorTreeAnalysis>(F);
-  // ClassID 0: ScalarRC
-  // ClassID 1: RegisterRC
   // TLI = &FAM.getResult<llvm::TargetLibraryAnalysis>(F);
   TTI = &FAM.getResult<llvm::TargetIRAnalysis>(F);
-  // llvm::errs() << "DataLayout: "
-  //              << F.getParent()->getDataLayout().getStringRepresentation()
-  //              << "\n";
-
-  // for (size_t i = 0; i < 5; ++i) {
-  //   size_t w = 1 << i;
-  //   llvm::errs() << "Vector width: " << w << "\nfadd cost: "
-  //                << TTI->getArithmeticInstrCost(
-  //                     llvm::Instruction::FAdd,
-  //                     llvm::FixedVectorType::get(
-  //                       llvm::Type::getDoubleTy(F.getContext()), w))
-  //                << "\n";
-  // }
-
   LI = &FAM.getResult<llvm::LoopAnalysis>(F);
   SE = &FAM.getResult<llvm::ScalarEvolutionAnalysis>(F);
   ORE = &FAM.getResult<llvm::OptimizationRemarkEmitterAnalysis>(F);

--- a/lib/TurboLoop.cpp
+++ b/lib/TurboLoop.cpp
@@ -112,7 +112,7 @@ auto TurboLoopPass::run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM)
       if (optDeps) {
         llvm::SmallVector<char, 512> str;
         llvm::raw_svector_ostream os(str);
-        os << "Solved linear program\n:" << loopBlock << "\n";
+        os << "Solved linear program:" << loopBlock << "\n";
         remark("LinearProgramSuccess", forest->getOuterLoop(), os.str());
       } else {
         remark("LinearProgramFailure", forest->getOuterLoop(),

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ debug_args = ['-Wall', '-Wextra', '-Wpedantic']
 
 # require clang for pch, as clang's pch should be clangd-compatible
 # if meson.get_compiler('cpp').get_id() == 'clang'
-shared_module('TurboLoop', 'lib/TurboLoop.cpp', dependencies : llvm_dep, include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath, cpp_pch : 'include/pch/turbo.hpp')
+turbo_module = shared_module('TurboLoop', 'lib/TurboLoop.cpp', dependencies : llvm_dep, include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath, cpp_pch : 'include/pch/turbo.hpp')
 # else
 #   shared_module('TurboLoop', 'lib/TurboLoop.cpp', dependencies : llvm_dep, include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
 # endif
@@ -52,6 +52,9 @@ if get_option('test')
       test_exe = executable(f, 'test' / f + '.cpp', dependencies : testdeps, include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath, cpp_pch : 'include/pch' / f + '.hpp')
       test(f, test_exe)
     endforeach
+    turbo_dep = declare_dependency(dependencies : [turbo_module])
+    remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', dependencies : [gtest_dep,turbo_dep], include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
+    test('remarks_test', remark_test_exe)
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -29,10 +29,10 @@ turbo_module = shared_module('TurboLoop', 'lib/TurboLoop.cpp', dependencies : ll
 if get_option('test')
   gtest_dep = dependency('gtest', main : true, fallback : ['gtest', 'gtest_main_dep'])
   if gtest_dep.found()
-    
-    remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
-    test('remarks_test', remark_test_exe, depends: [turbo_module], args: [turbo_module.full_path(), meson.source_root() / 'test' / 'examples'])
-
+    if get_option('testremarks')
+      remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
+      test('remarks_test', remark_test_exe, depends: [turbo_module], args: [turbo_module.full_path(), meson.source_root() / 'test' / 'examples'])
+    endif
     testdeps = [gtest_dep, llvm_dep]
 
     test_files = [

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,10 @@ turbo_module = shared_module('TurboLoop', 'lib/TurboLoop.cpp', dependencies : ll
 if get_option('test')
   gtest_dep = dependency('gtest', main : true, fallback : ['gtest', 'gtest_main_dep'])
   if gtest_dep.found()
+    
+    remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
+    test('remarks_test', remark_test_exe, depends: [turbo_module], args: [turbo_module.full_path(), meson.source_root() / 'test' / 'examples'])
+
     testdeps = [gtest_dep, llvm_dep]
 
     test_files = [
@@ -52,9 +56,6 @@ if get_option('test')
       test_exe = executable(f, 'test' / f + '.cpp', dependencies : testdeps, include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath, cpp_pch : 'include/pch' / f + '.hpp')
       test(f, test_exe)
     endforeach
-    
-    remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
-    test('remarks_test', remark_test_exe, depends: [turbo_module], args: [turbo_module.full_path(), meson.source_root() / 'test' / 'examples'])
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -52,9 +52,9 @@ if get_option('test')
       test_exe = executable(f, 'test' / f + '.cpp', dependencies : testdeps, include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath, cpp_pch : 'include/pch' / f + '.hpp')
       test(f, test_exe)
     endforeach
-    turbo_dep = declare_dependency(dependencies : [turbo_module])
-    remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', dependencies : [gtest_dep,turbo_dep], include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
-    test('remarks_test', remark_test_exe)
+    
+    remark_test_exe = executable('remarks_test', 'test' / 'remarks_test.cpp', include_directories: incdir, cpp_args : debug_args, build_rpath : llvm_rpath)
+    test('remarks_test', remark_test_exe, depends: [turbo_module], args: [turbo_module.full_path(), meson.source_root() / 'test' / 'examples'])
   endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('test', type : 'boolean', value : true)
+option('testremarks', type : 'boolean', value : true)
 option('benchmark', type : 'boolean', value : false)
+

--- a/test/bitset_test.cpp
+++ b/test/bitset_test.cpp
@@ -1,7 +1,7 @@
 #include "../include/BitSets.hpp"
-#include "../include/Math.hpp"
 #include <gtest/gtest.h>
 
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(BitSetTest, BasicAssertions) {
   BitSet bs(1000);
   bs[4] = true;

--- a/test/comparator_test.cpp
+++ b/test/comparator_test.cpp
@@ -88,9 +88,6 @@ TEST(V2Matrix, BasicAssertions) {
 TEST(ConstantTest, BasicAssertions) {
   auto A{stringToIntMatrix("[0 1 0; -1 1 -1; 0 0 1; -2 1 -1; 1 0 1]")};
   auto comp = LinearSymbolicComparator::construct(A);
-  SHOWLN(comp.U);
-  SHOWLN(comp.V);
-  SHOWLN(comp.d);
   Vector<int64_t> query0{-1, 0, 0};
   Vector<int64_t> query1{1, 0, 0};
   EXPECT_FALSE(comp.greaterEqual(query0));
@@ -102,9 +99,6 @@ TEST(ConstantTest, BasicAssertions) {
 TEST(ConstantTest2, BasicAssertions) {
   auto A{stringToIntMatrix("[0 1 0; -1 1 -1; 0 0 1; -2 1 -1; 1 0 1]")};
   auto comp = LinearSymbolicComparator::construct(A, false);
-  SHOWLN(comp.U);
-  SHOWLN(comp.V);
-  SHOWLN(comp.d);
   Vector<int64_t> query0{-1, 0, 0};
   Vector<int64_t> query1{1, 0, 0};
   EXPECT_FALSE(comp.greaterEqual(query0));
@@ -119,8 +113,6 @@ TEST(EqTest, BasicAssertions) {
   IntMatrix E{stringToIntMatrix("[1 0 0 1 0 -1 0; 1 0 0 0 1 0 -1]")};
   auto comp = LinearSymbolicComparator::construct(A, E);
   Vector<int64_t> diff = A(7, _) - A(3, _);
-  SHOWLN(comp.greaterEqual(diff));
-  SHOWLN(comp.greater(diff));
   EXPECT_TRUE(comp.greaterEqual(diff));
   EXPECT_TRUE(comp.greater(diff));
   diff *= -1;

--- a/test/compat_test.cpp
+++ b/test/compat_test.cpp
@@ -1,5 +1,4 @@
 #include "../include/Loops.hpp"
-#include "../include/Macro.hpp"
 #include "../include/Math.hpp"
 #include "../include/MatrixStringParse.hpp"
 #include "../include/TestUtilities.hpp"
@@ -40,8 +39,7 @@ TEST(TrivialPruneBounds, BasicAssertions) {
   tlf.addLoop(std::move(A), 1);
   AffineLoopNest<true> &aff = tlf.alns[0];
   aff.pruneBounds();
-  llvm::errs() << aff << "\n";
-  SHOWLN(aff.A);
+  llvm::errs() << aff << "\naff.A = " << aff.A << "\n";
   // M >= 0 is redundant
   // because M - 1 >= m >= 0
   // hence, we should be left with 1 bound (-2 + M - m >= 0)
@@ -62,7 +60,7 @@ TEST(TrivialPruneBounds2, BasicAssertions) {
   AffineLoopNest<true> &aff = tlf.alns[0];
   aff.pruneBounds();
   aff.dump();
-  SHOWLN(aff.A);
+  llvm::errs() << "aff.A = " << aff.A << "\n";
   // we expect J >= 1 to be dropped
   // because J >= i + 1 >= 2
   // because i >= 1
@@ -90,7 +88,7 @@ TEST(LessTrivialPruneBounds, BasicAssertions) {
   aff.pruneBounds();
   llvm::errs() << "LessTrival test Bounds pruned:\n";
   aff.dump();
-  SHOWLN(aff.A);
+  llvm::errs() << "aff.A = " << aff.A << "\n";
   EXPECT_EQ(aff.A.numRow(), 3);
   auto loop2Count = countSigns(aff.A, 2 + aff.getNumSymbols());
   EXPECT_EQ(loop2Count.first, 1);

--- a/test/compat_test.cpp
+++ b/test/compat_test.cpp
@@ -2,12 +2,22 @@
 #include "../include/Math.hpp"
 #include "../include/MatrixStringParse.hpp"
 #include "../include/TestUtilities.hpp"
+#include "Constraints.hpp"
 #include <cstdint>
 #include <cstdio>
 #include <gtest/gtest.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
 #include <memory>
+
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
+TEST(FourierMotzkin, BasicAssertions) {
+  auto A{stringToIntMatrix("[-2 1 0 -1 -1 0; -1 0 1 0 0 -1]")};
+  fourierMotzkinNonNegative(A, 3);
+  auto B{stringToIntMatrix("[-2 1 0 0 -1 0; -1 0 1 0 0 -1]")};
+  llvm::errs() << "A = " << A << "\nB = " << B << "\n";
+  EXPECT_EQ(A, B);
+}
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(TrivialPruneBounds, BasicAssertions) {

--- a/test/cost_modeling_test.cpp
+++ b/test/cost_modeling_test.cpp
@@ -2,7 +2,6 @@
 #include "../include/DependencyPolyhedra.hpp"
 #include "../include/LoopBlock.hpp"
 #include "../include/Loops.hpp"
-#include "../include/Macro.hpp"
 #include "../include/Math.hpp"
 #include "../include/MatrixStringParse.hpp"
 #include "../include/MemoryAccess.hpp"

--- a/test/dependence_test.cpp
+++ b/test/dependence_test.cpp
@@ -2,7 +2,6 @@
 #include "../include/DependencyPolyhedra.hpp"
 #include "../include/LoopBlock.hpp"
 #include "../include/Loops.hpp"
-#include "../include/Macro.hpp"
 #include "../include/Math.hpp"
 #include "../include/MatrixStringParse.hpp"
 #include "../include/TestUtilities.hpp"
@@ -120,7 +119,6 @@ TEST(DependenceTest, BasicAssertions) {
   schStore[2] = 2;
   MemoryAccess msrc{Asrc, Astore11, schStore};
   MemoryAccess mtgt01{Atgt01, Aload01, schLoad0};
-  SHOWLN(loop.S[0]);
   DependencePolyhedra dep0(msrc, mtgt01);
   EXPECT_FALSE(dep0.isEmpty());
   dep0.pruneBounds();
@@ -150,14 +148,6 @@ TEST(DependenceTest, BasicAssertions) {
   Dependence &d(dc.front());
   EXPECT_TRUE(d.forward);
   llvm::errs() << d << "\n";
-  SHOWLN(d.getNumPhiCoefficients());
-  SHOWLN(d.getNumOmegaCoefficients());
-  SHOWLN(d.depPoly.getDim0());
-  SHOWLN(d.depPoly.getDim1());
-  SHOWLN(d.depPoly.getNumVar());
-  SHOWLN(d.depPoly.nullStep.size());
-  SHOWLN(d.depPoly.getNumSymbols());
-  SHOWLN(d.depPoly.A.numCol());
   assert(d.forward);
   assert(!allZero(d.dependenceSatisfaction.tableau(
     d.dependenceSatisfaction.tableau.numRow() - 1, _)));
@@ -237,8 +227,6 @@ TEST(SymmetricIndependentTest, BasicAssertions) {
   MemoryAccess mtgt{Atgt, Aloadji, schLoad};
   DependencePolyhedra dep(msrc, mtgt);
   llvm::errs() << "Dep = \n" << dep << "\n";
-  SHOWLN(dep.A);
-  SHOWLN(dep.E);
   EXPECT_TRUE(dep.isEmpty());
   assert(dep.isEmpty());
   //
@@ -525,16 +513,6 @@ TEST(TriangularExampleTest, BasicAssertions) {
                        "fsub"),
     Ageped0, llvm::MaybeAlign(8), false);
 
-  SHOWLN(Aload1mk);
-  for (auto &use : Aload1mk->uses())
-    SHOWLN(use.getUser());
-  SHOWLN(Aload1mn);
-  for (auto &use : Aload1mn->uses())
-    SHOWLN(use.getUser());
-  SHOWLN(Uloadnk);
-  for (auto &use : Uloadnk->uses())
-    SHOWLN(use.getUser());
-  SHOWLN(Astore2mk);
   // badly written triangular solve:
   // for (m = 0; m < M; ++m){
   //   for (n = 0; n < N; ++n){
@@ -836,7 +814,6 @@ TEST(TriangularExampleTest, BasicAssertions) {
 
   std::optional<BitSet<>> optDeps = lblock.optimize();
   EXPECT_TRUE(optDeps.has_value());
-  SHOWLN(lblock);
   // orig order (inner <-> outer): n, m
   IntMatrix optPhi2(2, 2);
   // phi2 loop order is
@@ -852,22 +829,15 @@ TEST(TriangularExampleTest, BasicAssertions) {
   // optPhi3(end, _) = std::numeric_limits<int64_t>::min();
   // assert(!optFail);
   for (auto mem : lblock.memory) {
-    SHOW(mem->nodeIndex);
-    CSHOWLN(mem->ref);
     for (size_t nodeIndex : mem->nodeIndex) {
       Schedule &s = lblock.nodes[nodeIndex].schedule;
-      SHOWLN(s.getPhi());
-      SHOWLN(s.getFusionOmega());
-      SHOWLN(s.getOffsetOmega());
       if (mem->getNumLoops() == 2) {
         EXPECT_EQ(s.getPhi(), optPhi2);
       } else {
         assert(mem->getNumLoops() == 3);
         EXPECT_EQ(s.getPhi(), optPhi3);
       }
-      // SHOWLN(mem.schedule.getPhi());
-      // SHOWLN(mem.schedule.getOmega());
-      llvm::errs() << "\n";
+      //       //       llvm::errs() << "\n";
     }
   }
 }
@@ -1117,32 +1087,6 @@ TEST(MeanStDevTest0, BasicAssertions) {
   sch0_6[1] = 6;
   llvm::SmallVector<unsigned, 8> sch0_7(1 + 1);
   sch0_7[1] = 7;
-  // SHOWLN(sch1_0.getPhi());
-  // SHOWLN(sch2_1_0.getPhi());
-  // SHOWLN(sch2_1_1.getPhi());
-  // SHOWLN(sch2_1_2.getPhi());
-  // SHOWLN(sch1_2.getPhi());
-  // SHOWLN(sch1_3.getPhi());
-  // SHOWLN(sch1_4.getPhi());
-  // SHOWLN(sch2_5_0.getPhi());
-  // SHOWLN(sch2_5_1.getPhi());
-  // SHOWLN(sch2_5_2.getPhi());
-  // SHOWLN(sch2_5_3.getPhi());
-  // SHOWLN(sch1_6.getPhi());
-  // SHOWLN(sch1_7.getPhi());
-  // SHOWLN(sch1_0.getOmega());
-  // SHOWLN(sch2_1_0.getOmega());
-  // SHOWLN(sch2_1_1.getOmega());
-  // SHOWLN(sch2_1_2.getOmega());
-  // SHOWLN(sch1_2.getOmega());
-  // SHOWLN(sch1_3.getOmega());
-  // SHOWLN(sch1_4.getOmega());
-  // SHOWLN(sch2_5_0.getOmega());
-  // SHOWLN(sch2_5_1.getOmega());
-  // SHOWLN(sch2_5_2.getOmega());
-  // SHOWLN(sch2_5_3.getOmega());
-  // SHOWLN(sch1_6.getOmega());
-  // SHOWLN(sch1_7.getOmega());
   LinearProgramLoopBlock iOuterLoopNest;
   llvm::SmallVector<MemoryAccess, 0> iOuterMem;
   iOuterMem.emplace_back(xInd1, Xstore_0, sch0_0); // 0
@@ -1179,7 +1123,6 @@ TEST(MeanStDevTest0, BasicAssertions) {
 
   std::optional<BitSet<>> optDeps = iOuterLoopNest.optimize();
   EXPECT_TRUE(optDeps.has_value());
-  SHOWLN(iOuterLoopNest);
   llvm::DenseMap<MemoryAccess *, size_t> memAccessIds;
   for (size_t i = 0; i < iOuterLoopNest.memory.size(); ++i)
     memAccessIds[iOuterLoopNest.memory[i]] = i;
@@ -1203,13 +1146,13 @@ TEST(MeanStDevTest0, BasicAssertions) {
   }
   // Graphs::print(iOuterLoopNest.fullGraph());
   for (auto mem : iOuterLoopNest.memory) {
-    SHOW(mem->nodeIndex);
-    CSHOWLN(mem->ref);
+    llvm::errs() << "mem->nodeIndex =" << mem->nodeIndex << ";";
+    llvm::errs() << "mem->ref =" << mem->ref << "\n";
     for (size_t nodeIndex : mem->nodeIndex) {
       Schedule &s = iOuterLoopNest.nodes[nodeIndex].schedule;
-      SHOWLN(s.getPhi());
-      SHOWLN(s.getFusionOmega());
-      SHOWLN(s.getOffsetOmega());
+      llvm::errs() << "s.getPhi() =" << s.getPhi() << "\n";
+      llvm::errs() << "s.getFusionOmega() =" << s.getFusionOmega() << "\n";
+      llvm::errs() << "s.getOffsetOmega() =" << s.getOffsetOmega() << "\n";
     }
   }
 
@@ -1268,8 +1211,6 @@ TEST(MeanStDevTest0, BasicAssertions) {
     jOuterLoopNest.memory.push_back(&mem);
 
   EXPECT_TRUE(jOuterLoopNest.optimize().has_value());
-  SHOW(jOuterLoopNest.edges.size());
-  CSHOWLN(jOuterLoopNest.memory.size());
   for (auto &edge : jOuterLoopNest.edges)
     llvm::errs() << "\nedge = " << edge << "\n";
 
@@ -1291,15 +1232,9 @@ TEST(MeanStDevTest0, BasicAssertions) {
   optS.diag() = 1;
   IntMatrix optSinnerUndef = optS;
   optSinnerUndef(1, _) = std::numeric_limits<int64_t>::min();
-  SHOWLN(jOuterLoopNest);
   for (auto mem : jOuterLoopNest.memory) {
-    SHOW(mem->nodeIndex);
-    CSHOWLN(mem->ref);
     for (size_t nodeIndex : mem->nodeIndex) {
       Schedule &s = jOuterLoopNest.nodes[nodeIndex].schedule;
-      SHOWLN(s.getPhi());
-      SHOWLN(s.getFusionOmega());
-      SHOWLN(s.getOffsetOmega());
       if (s.getNumLoops() == 1)
         EXPECT_EQ(s.getPhi()(0, 0), 1);
       else if (s.getFusionOmega()(1) < 3)
@@ -1451,14 +1386,6 @@ TEST(DoubleDependenceTest, BasicAssertions) {
   Dependence &d(dc.front());
   EXPECT_TRUE(d.forward);
   llvm::errs() << d << "\n";
-  SHOWLN(d.getNumPhiCoefficients());
-  SHOWLN(d.getNumOmegaCoefficients());
-  SHOWLN(d.depPoly.getDim0());
-  SHOWLN(d.depPoly.getDim1());
-  SHOWLN(d.depPoly.getNumVar());
-  SHOWLN(d.depPoly.nullStep.size());
-  SHOWLN(d.depPoly.getNumSymbols());
-  SHOWLN(d.depPoly.A.numCol());
   assert(d.forward);
   assert(!allZero(d.dependenceSatisfaction.tableau(
     d.dependenceSatisfaction.tableau.numRow() - 1, _)));
@@ -1499,14 +1426,9 @@ TEST(DoubleDependenceTest, BasicAssertions) {
   optPhi(1, _) = std::numeric_limits<int64_t>::min();
   // Graphs::print(iOuterLoopNest.fullGraph());
   for (auto &mem : loopBlock.memory) {
-    SHOW(mem->nodeIndex);
-    CSHOWLN(mem->ref);
     for (size_t nodeIndex : mem->nodeIndex) {
       Schedule &s = loopBlock.nodes[nodeIndex].schedule;
-      SHOWLN(s.getPhi());
       EXPECT_EQ(s.getPhi(), optPhi);
-      SHOWLN(s.getFusionOmega());
-      SHOWLN(s.getOffsetOmega());
     }
   }
 }
@@ -1664,14 +1586,14 @@ TEST(ConvReversePass, BasicAssertions) {
   std::optional<BitSet<>> optRes = loopBlock.optimize();
   EXPECT_TRUE(optRes.has_value());
   for (auto &mem : loopBlock.memory) {
-    SHOW(mem->nodeIndex);
-    CSHOWLN(mem->ref);
+    llvm::errs() << "mem->nodeIndex: " << mem->nodeIndex << "; ";
+    llvm::errs() << "mem->ref: " << mem->ref << "\n";
     for (size_t nodeIndex : mem->nodeIndex) {
       Schedule &s = loopBlock.nodes[nodeIndex].schedule;
-      SHOWLN(s.getPhi());
+      llvm::errs() << "s.getPhi(): " << s.getPhi() << "\n";
+      llvm::errs() << "s.getFusionOmega(): " << s.getFusionOmega() << "\n";
+      llvm::errs() << "s.getOffsetOmega(): " << s.getOffsetOmega() << "\n";
       // EXPECT_EQ(s.getPhi(), optPhi);
-      SHOWLN(s.getFusionOmega());
-      SHOWLN(s.getOffsetOmega());
     }
   }
 }

--- a/test/examples/triangular_solve.ll
+++ b/test/examples/triangular_solve.ll
@@ -1,0 +1,396 @@
+; ModuleID = '/home/chriselrod/Documents/progwork/cxx/LoopPlayground/LoopInductTests/test/triangular_solve.ll'
+source_filename = "triangular_solve!"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define nonnull {} addrspace(10)* @"japi1_triangular_solve!_1048"({} addrspace(10)* %0, {} addrspace(10)** noalias nocapture noundef readonly %1, i32 %2) #0 !dbg !4 {
+top:
+  %3 = alloca [2 x {} addrspace(10)*], align 8
+  %gcframe68 = alloca [3 x {} addrspace(10)*], align 16
+  %gcframe68.sub = getelementptr inbounds [3 x {} addrspace(10)*], [3 x {} addrspace(10)*]* %gcframe68, i64 0, i64 0
+  %.sub = getelementptr inbounds [2 x {} addrspace(10)*], [2 x {} addrspace(10)*]* %3, i64 0, i64 0
+  %4 = bitcast [3 x {} addrspace(10)*]* %gcframe68 to i8*
+  call void @llvm.memset.p0i8.i32(i8* noundef nonnull align 16 dereferenceable(24) %4, i8 0, i32 24, i1 false), !tbaa !7
+  %5 = alloca {} addrspace(10)**, align 8
+  store volatile {} addrspace(10)** %1, {} addrspace(10)*** %5, align 8
+  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #8
+  %ppgcstack_i8 = getelementptr i8, i8* %thread_ptr, i64 -8
+  %ppgcstack = bitcast i8* %ppgcstack_i8 to {}****
+  %pgcstack = load {}***, {}**** %ppgcstack, align 8
+  %6 = bitcast [3 x {} addrspace(10)*]* %gcframe68 to i64*
+  store i64 4, i64* %6, align 16, !tbaa !7
+  %7 = getelementptr inbounds [3 x {} addrspace(10)*], [3 x {} addrspace(10)*]* %gcframe68, i64 0, i64 1
+  %8 = bitcast {} addrspace(10)** %7 to {}***
+  %9 = load {}**, {}*** %pgcstack, align 8
+  store {}** %9, {}*** %8, align 8, !tbaa !7
+  %10 = bitcast {}*** %pgcstack to {} addrspace(10)***
+  store {} addrspace(10)** %gcframe68.sub, {} addrspace(10)*** %10, align 8
+  %11 = load {} addrspace(10)*, {} addrspace(10)** %1, align 8, !tbaa !11, !nonnull !6, !dereferenceable !13, !align !14
+  %12 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)** %1, i64 1
+  %13 = load {} addrspace(10)*, {} addrspace(10)** %12, align 8, !tbaa !11, !nonnull !6, !dereferenceable !13, !align !14
+  %14 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)** %1, i64 2
+  %15 = load {} addrspace(10)*, {} addrspace(10)** %14, align 8, !tbaa !11, !nonnull !6, !dereferenceable !13, !align !14
+  %16 = bitcast {} addrspace(10)* %11 to {} addrspace(10)* addrspace(10)*, !dbg !15
+  %17 = addrspacecast {} addrspace(10)* addrspace(10)* %16 to {} addrspace(10)* addrspace(11)*, !dbg !15
+  %18 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %17, i64 3, !dbg !15
+  %19 = bitcast {} addrspace(10)* addrspace(11)* %18 to i64 addrspace(11)*, !dbg !15
+  %20 = load i64, i64 addrspace(11)* %19, align 8, !dbg !15, !tbaa !11, !range !19
+  %21 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %17, i64 4, !dbg !15
+  %22 = bitcast {} addrspace(10)* addrspace(11)* %21 to i64 addrspace(11)*, !dbg !15
+  %23 = load i64, i64 addrspace(11)* %22, align 8, !dbg !15, !tbaa !11, !range !19
+  %24 = bitcast {} addrspace(10)* %13 to {} addrspace(10)* addrspace(10)*, !dbg !20
+  %25 = addrspacecast {} addrspace(10)* addrspace(10)* %24 to {} addrspace(10)* addrspace(11)*, !dbg !20
+  %26 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %25, i64 3, !dbg !20
+  %27 = bitcast {} addrspace(10)* addrspace(11)* %26 to i64 addrspace(11)*, !dbg !20
+  %28 = load i64, i64 addrspace(11)* %27, align 8, !dbg !20, !tbaa !11, !range !19
+  %.not = icmp eq i64 %20, %28, !dbg !22
+  br i1 %.not, label %L6, label %L162, !dbg !21
+
+L6:                                               ; preds = %top
+  %29 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %25, i64 4, !dbg !25
+  %30 = bitcast {} addrspace(10)* addrspace(11)* %29 to i64 addrspace(11)*, !dbg !25
+  %31 = load i64, i64 addrspace(11)* %30, align 8, !dbg !25, !tbaa !11, !range !19
+  %.not45 = icmp eq i64 %23, %31, !dbg !27
+  br i1 %.not45, label %L10, label %L159, !dbg !26
+
+L10:                                              ; preds = %L6
+  %32 = bitcast {} addrspace(10)* %15 to {} addrspace(10)* addrspace(10)*, !dbg !28
+  %33 = addrspacecast {} addrspace(10)* addrspace(10)* %32 to {} addrspace(10)* addrspace(11)*, !dbg !28
+  %34 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %33, i64 3, !dbg !28
+  %35 = bitcast {} addrspace(10)* addrspace(11)* %34 to i64 addrspace(11)*, !dbg !28
+  %36 = load i64, i64 addrspace(11)* %35, align 8, !dbg !28, !tbaa !11, !range !19
+  %37 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %33, i64 4, !dbg !28
+  %38 = bitcast {} addrspace(10)* addrspace(11)* %37 to i64 addrspace(11)*, !dbg !28
+  %39 = load i64, i64 addrspace(11)* %38, align 8, !dbg !28, !tbaa !11, !range !19
+  %.not46 = icmp eq i64 %36, %39, !dbg !32
+  br i1 %.not46, label %L22, label %L15, !dbg !33
+
+L15:                                              ; preds = %L10
+  %ptls_field72 = getelementptr inbounds {}**, {}*** %pgcstack, i64 2, !dbg !34
+  %40 = bitcast {}*** %ptls_field72 to i8**, !dbg !34
+  %ptls_load7374 = load i8*, i8** %40, align 8, !dbg !34, !tbaa !7
+  %41 = call noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc(i8* %ptls_load7374, i32 1440, i32 32) #3, !dbg !34
+  %42 = bitcast {} addrspace(10)* %41 to i64 addrspace(10)*, !dbg !34
+  %43 = getelementptr inbounds i64, i64 addrspace(10)* %42, i64 -1, !dbg !34
+  store atomic i64 140097055433888, i64 addrspace(10)* %43 unordered, align 8, !dbg !34, !tbaa !37
+  %44 = bitcast {} addrspace(10)* %41 to i8 addrspace(10)*, !dbg !34
+  store i64 %36, i64 addrspace(10)* %42, align 8, !dbg !34, !tbaa !40
+  %.sroa.2.0..sroa_idx = getelementptr inbounds i8, i8 addrspace(10)* %44, i64 8, !dbg !34
+  %.sroa.2.0..sroa_cast = bitcast i8 addrspace(10)* %.sroa.2.0..sroa_idx to i64 addrspace(10)*, !dbg !34
+  store i64 %39, i64 addrspace(10)* %.sroa.2.0..sroa_cast, align 8, !dbg !34, !tbaa !40
+  %45 = getelementptr inbounds [3 x {} addrspace(10)*], [3 x {} addrspace(10)*]* %gcframe68, i64 0, i64 2
+  store {} addrspace(10)* %41, {} addrspace(10)** %45, align 16
+  store {} addrspace(10)* addrspacecast ({}* inttoptr (i64 140097123828736 to {}*) to {} addrspace(10)*), {} addrspace(10)** %.sub, align 8, !dbg !34
+  %46 = getelementptr inbounds [2 x {} addrspace(10)*], [2 x {} addrspace(10)*]* %3, i64 0, i64 1, !dbg !34
+  store {} addrspace(10)* %41, {} addrspace(10)** %46, align 8, !dbg !34
+  %47 = call nonnull {} addrspace(10)* @j1_print_to_string_1049({} addrspace(10)* addrspacecast ({}* inttoptr (i64 140097056873856 to {}*) to {} addrspace(10)*), {} addrspace(10)** nonnull %.sub, i32 2), !dbg !34
+  store {} addrspace(10)* %47, {} addrspace(10)** %45, align 16
+  store {} addrspace(10)* %47, {} addrspace(10)** %.sub, align 8, !dbg !33
+  %48 = call nonnull {} addrspace(10)* @ijl_apply_generic({} addrspace(10)* addrspacecast ({}* inttoptr (i64 140097057827712 to {}*) to {} addrspace(10)*), {} addrspace(10)** nonnull %.sub, i32 1), !dbg !33
+  %49 = addrspacecast {} addrspace(10)* %48 to {} addrspace(12)*, !dbg !33
+  call void @ijl_throw({} addrspace(12)* %49), !dbg !33
+  unreachable, !dbg !33
+
+L22:                                              ; preds = %L10
+  %.not62 = icmp eq i64 %23, %36, !dbg !27
+  br i1 %.not62, label %L27, label %L159, !dbg !26
+
+L27:                                              ; preds = %L22
+  %.not48.not = icmp eq i64 %20, 0, !dbg !41
+  br i1 %.not48.not, label %L158, label %L44.preheader, !dbg !52
+
+L44.preheader:                                    ; preds = %L27
+  %cond = icmp eq i64 %23, 0
+  %50 = bitcast {} addrspace(10)* %13 to double addrspace(13)* addrspace(10)*
+  %51 = addrspacecast double addrspace(13)* addrspace(10)* %50 to double addrspace(13)* addrspace(11)*
+  %52 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %51, align 8
+  %53 = bitcast {} addrspace(10)* %11 to double addrspace(13)* addrspace(10)*
+  %54 = addrspacecast double addrspace(13)* addrspace(10)* %53 to double addrspace(13)* addrspace(11)*
+  %55 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %54, align 8
+  %56 = bitcast {} addrspace(10)* %15 to double addrspace(13)* addrspace(10)*
+  %57 = addrspacecast double addrspace(13)* addrspace(10)* %56 to double addrspace(13)* addrspace(11)*
+  %58 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %57, align 8
+  br i1 %cond, label %L158, label %L62.preheader.preheader, !dbg !53
+
+L62.preheader.preheader:                          ; preds = %L44.preheader
+  br label %L62.preheader, !dbg !54
+
+L62.preheader:                                    ; preds = %L62.preheader.preheader, %L147
+  %value_phi5 = phi i64 [ %91, %L147 ], [ 1, %L62.preheader.preheader ]
+  %59 = add nsw i64 %value_phi5, -1
+  br label %L62, !dbg !54
+
+L62:                                              ; preds = %L62, %L62.preheader
+  %value_phi11 = phi i64 [ %66, %L62 ], [ 1, %L62.preheader ]
+  %60 = add nsw i64 %value_phi11, -1, !dbg !55
+  %61 = mul i64 %60, %20, !dbg !55
+  %62 = add i64 %59, %61, !dbg !55
+  %63 = getelementptr inbounds double, double addrspace(13)* %52, i64 %62, !dbg !55
+  %64 = load double, double addrspace(13)* %63, align 8, !dbg !55, !tbaa !59
+  %65 = getelementptr inbounds double, double addrspace(13)* %55, i64 %62, !dbg !61
+  store double %64, double addrspace(13)* %65, align 8, !dbg !61, !tbaa !59
+  %.not51.not = icmp eq i64 %value_phi11, %23, !dbg !63
+  %66 = add nuw nsw i64 %value_phi11, 1, !dbg !64
+  br i1 %.not51.not, label %L93.preheader, label %L62, !dbg !54
+
+L93.preheader:                                    ; preds = %L62
+  br label %L93, !dbg !65
+
+L93:                                              ; preds = %L93.preheader, %L136
+  %value_phi20 = phi i64 [ %77, %L136 ], [ 1, %L93.preheader ]
+  %67 = add nsw i64 %value_phi20, -1, !dbg !66
+  %68 = mul i64 %67, %20, !dbg !66
+  %69 = add i64 %59, %68, !dbg !66
+  %70 = getelementptr inbounds double, double addrspace(13)* %55, i64 %69, !dbg !66
+  %71 = load double, double addrspace(13)* %70, align 8, !dbg !66, !tbaa !59
+  %72 = mul i64 %23, %67, !dbg !66
+  %73 = add i64 %67, %72, !dbg !66
+  %74 = getelementptr inbounds double, double addrspace(13)* %58, i64 %73, !dbg !66
+  %75 = load double, double addrspace(13)* %74, align 8, !dbg !66, !tbaa !59
+  %76 = fdiv double %71, %75, !dbg !68
+  store double %76, double addrspace(13)* %70, align 8, !dbg !71, !tbaa !59
+  %77 = add nuw nsw i64 %value_phi20, 1, !dbg !72
+  %.not54.not = icmp ult i64 %value_phi20, %23, !dbg !74
+  %value_phi22 = select i1 %.not54.not, i64 %23, i64 %value_phi20, !dbg !78
+  %.not55.not.not = icmp sgt i64 %value_phi22, %value_phi20, !dbg !84
+  br i1 %.not55.not.not, label %L117.preheader, label %L136, !dbg !65
+
+L117.preheader:                                   ; preds = %L93
+  br label %L117, !dbg !88
+
+L117:                                             ; preds = %L117.preheader, %L117.L117_crit_edge
+  %78 = phi double [ %.pre, %L117.L117_crit_edge ], [ %76, %L117.preheader ], !dbg !89
+  %value_phi26 = phi i64 [ %90, %L117.L117_crit_edge ], [ %77, %L117.preheader ]
+  %79 = add i64 %value_phi26, -1, !dbg !89
+  %80 = mul i64 %79, %20, !dbg !89
+  %81 = add i64 %59, %80, !dbg !89
+  %82 = getelementptr inbounds double, double addrspace(13)* %55, i64 %81, !dbg !89
+  %83 = load double, double addrspace(13)* %82, align 8, !dbg !89, !tbaa !59
+  %84 = mul i64 %23, %79, !dbg !89
+  %85 = add i64 %67, %84, !dbg !89
+  %86 = getelementptr inbounds double, double addrspace(13)* %58, i64 %85, !dbg !89
+  %87 = load double, double addrspace(13)* %86, align 8, !dbg !89, !tbaa !59
+  %88 = fmul double %78, %87, !dbg !91
+  %89 = fsub double %83, %88, !dbg !93
+  store double %89, double addrspace(13)* %82, align 8, !dbg !95, !tbaa !59
+  %.not56.not = icmp eq i64 %value_phi26, %value_phi22, !dbg !96
+  br i1 %.not56.not, label %L136.loopexit, label %L117.L117_crit_edge, !dbg !88
+
+L117.L117_crit_edge:                              ; preds = %L117
+  %90 = add i64 %value_phi26, 1, !dbg !97
+  %.pre = load double, double addrspace(13)* %70, align 8, !dbg !89, !tbaa !59
+  br label %L117, !dbg !88
+
+L136.loopexit:                                    ; preds = %L117
+  br label %L136, !dbg !98
+
+L136:                                             ; preds = %L136.loopexit, %L93
+  %.not57.not = icmp eq i64 %value_phi20, %23, !dbg !98
+  br i1 %.not57.not, label %L147, label %L93, !dbg !100
+
+L147:                                             ; preds = %L136
+  %.not58 = icmp eq i64 %value_phi5, %20, !dbg !101
+  %91 = add nuw nsw i64 %value_phi5, 1, !dbg !102
+  br i1 %.not58, label %L158.loopexit, label %L62.preheader, !dbg !103
+
+L158.loopexit:                                    ; preds = %L147
+  br label %L158
+
+L158:                                             ; preds = %L158.loopexit, %L44.preheader, %L27
+  %92 = load {} addrspace(10)*, {} addrspace(10)** %7, align 8, !tbaa !7
+  %93 = bitcast {}*** %pgcstack to {} addrspace(10)**
+  store {} addrspace(10)* %92, {} addrspace(10)** %93, align 8, !tbaa !7
+  ret {} addrspace(10)* addrspacecast ({}* inttoptr (i64 140097280274440 to {}*) to {} addrspace(10)*), !dbg !103
+
+L159:                                             ; preds = %L22, %L6
+  store {} addrspace(10)* addrspacecast ({}* inttoptr (i64 140097271282704 to {}*) to {} addrspace(10)*), {} addrspace(10)** %.sub, align 8, !dbg !26
+  %94 = call nonnull {} addrspace(10)* @ijl_apply_generic({} addrspace(10)* addrspacecast ({}* inttoptr (i64 140097055238352 to {}*) to {} addrspace(10)*), {} addrspace(10)** nonnull %.sub, i32 1), !dbg !26
+  %95 = addrspacecast {} addrspace(10)* %94 to {} addrspace(12)*, !dbg !26
+  call void @ijl_throw({} addrspace(12)* %95), !dbg !26
+  unreachable, !dbg !26
+
+L162:                                             ; preds = %top
+  %ptls_field6569 = getelementptr inbounds {}**, {}*** %pgcstack, i64 2, !dbg !21
+  %96 = bitcast {}*** %ptls_field6569 to i8**, !dbg !21
+  %ptls_load667071 = load i8*, i8** %96, align 8, !dbg !21, !tbaa !7
+  %97 = call noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc(i8* %ptls_load667071, i32 1392, i32 16) #3, !dbg !21
+  %98 = bitcast {} addrspace(10)* %97 to i64 addrspace(10)*, !dbg !21
+  %99 = getelementptr inbounds i64, i64 addrspace(10)* %98, i64 -1, !dbg !21
+  store atomic i64 140097055238352, i64 addrspace(10)* %99 unordered, align 8, !dbg !21, !tbaa !37
+  %100 = bitcast {} addrspace(10)* %97 to {} addrspace(10)* addrspace(10)*, !dbg !21
+  store {} addrspace(10)* addrspacecast ({}* inttoptr (i64 140088539681296 to {}*) to {} addrspace(10)*), {} addrspace(10)* addrspace(10)* %100, align 8, !dbg !21, !tbaa !104
+  %101 = addrspacecast {} addrspace(10)* %97 to {} addrspace(12)*, !dbg !21
+  call void @ijl_throw({} addrspace(12)* %101), !dbg !21
+  unreachable, !dbg !21
+}
+
+declare nonnull {} addrspace(10)* @ijl_apply_generic({} addrspace(10)*, {} addrspace(10)** noalias nocapture noundef readonly, i32)
+
+declare nonnull {} addrspace(10)* @julia.call({} addrspace(10)* ({} addrspace(10)*, {} addrspace(10)**, i32)*, {} addrspace(10)*, ...)
+
+; Function Attrs: noreturn
+declare void @ijl_throw({} addrspace(12)*) #1
+
+; Function Attrs: cold noreturn nounwind
+declare void @llvm.trap() #2
+
+declare nonnull {} addrspace(10)* @j1_print_to_string_1049({} addrspace(10)*, {} addrspace(10)**, i32)
+
+; Function Attrs: allocsize(1)
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}**, i64, {} addrspace(10)*) #3
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn
+declare void @llvm.memcpy.p10i8.p0i8.i64(i8 addrspace(10)* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #4
+
+; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
+
+; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
+
+; Function Attrs: inaccessiblemem_or_argmemonly
+declare void @ijl_gc_queue_root({} addrspace(10)*) #6
+
+; Function Attrs: inaccessiblemem_or_argmemonly
+declare void @jl_gc_queue_binding({} addrspace(10)*) #6
+
+; Function Attrs: allocsize(1)
+declare noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc(i8*, i32, i32) #3
+
+; Function Attrs: allocsize(1)
+declare noalias nonnull {} addrspace(10)* @ijl_gc_big_alloc(i8*, i64) #3
+
+declare noalias nonnull {} addrspace(10)** @julia.new_gc_frame(i32)
+
+declare void @julia.push_gc_frame({} addrspace(10)**, i32)
+
+declare {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)**, i32)
+
+declare void @julia.pop_gc_frame({} addrspace(10)**)
+
+; Function Attrs: allocsize(1)
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_bytes(i8*, i64) #3
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #7
+
+attributes #0 = { "probe-stack"="inline-asm" }
+attributes #1 = { noreturn }
+attributes #2 = { cold noreturn nounwind }
+attributes #3 = { allocsize(1) }
+attributes #4 = { argmemonly nocallback nofree nounwind willreturn }
+attributes #5 = { argmemonly nocallback nofree nosync nounwind willreturn }
+attributes #6 = { inaccessiblemem_or_argmemonly }
+attributes #7 = { argmemonly nocallback nofree nounwind willreturn writeonly }
+attributes #8 = { nounwind }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 2, !"Dwarf Version", i32 4}
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+!2 = distinct !DICompileUnit(language: DW_LANG_Julia, file: !3, producer: "julia", isOptimized: true, runtimeVersion: 0, emissionKind: NoDebug, nameTableKind: GNU)
+!3 = !DIFile(filename: "REPL[26]", directory: ".")
+!4 = distinct !DISubprogram(name: "triangular_solve!", linkageName: "japi1_triangular_solve!_1048", scope: null, file: !3, line: 1, type: !5, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!5 = !DISubroutineType(types: !6)
+!6 = !{}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"jtbaa_gcframe", !9, i64 0}
+!9 = !{!"jtbaa", !10, i64 0}
+!10 = !{!"jtbaa"}
+!11 = !{!12, !12, i64 0}
+!12 = !{!"jtbaa_const", !9, i64 0}
+!13 = !{i64 40}
+!14 = !{i64 16}
+!15 = !DILocation(line: 150, scope: !16, inlinedAt: !18)
+!16 = distinct !DISubprogram(name: "size;", linkageName: "size", scope: !17, file: !17, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!17 = !DIFile(filename: "array.jl", directory: ".")
+!18 = !DILocation(line: 2, scope: !4)
+!19 = !{i64 0, i64 9223372036854775807}
+!20 = !DILocation(line: 148, scope: !16, inlinedAt: !21)
+!21 = !DILocation(line: 3, scope: !4)
+!22 = !DILocation(line: 499, scope: !23, inlinedAt: !21)
+!23 = distinct !DISubprogram(name: "==;", linkageName: "==", scope: !24, file: !24, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!24 = !DIFile(filename: "promotion.jl", directory: ".")
+!25 = !DILocation(line: 148, scope: !16, inlinedAt: !26)
+!26 = !DILocation(line: 4, scope: !4)
+!27 = !DILocation(line: 499, scope: !23, inlinedAt: !26)
+!28 = !DILocation(line: 150, scope: !16, inlinedAt: !29)
+!29 = !DILocation(line: 238, scope: !30, inlinedAt: !26)
+!30 = distinct !DISubprogram(name: "checksquare;", linkageName: "checksquare", scope: !31, file: !31, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!31 = !DIFile(filename: "/home/chriselrod/Documents/languages/julianovec/usr/share/julia/stdlib/v1.9/LinearAlgebra/src/LinearAlgebra.jl", directory: ".")
+!32 = !DILocation(line: 499, scope: !23, inlinedAt: !33)
+!33 = !DILocation(line: 239, scope: !30, inlinedAt: !26)
+!34 = !DILocation(line: 185, scope: !35, inlinedAt: !33)
+!35 = distinct !DISubprogram(name: "string;", linkageName: "string", scope: !36, file: !36, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!36 = !DIFile(filename: "strings/io.jl", directory: ".")
+!37 = !{!38, !38, i64 0}
+!38 = !{!"jtbaa_tag", !39, i64 0}
+!39 = !{!"jtbaa_data", !9, i64 0}
+!40 = !{!9, !9, i64 0}
+!41 = !DILocation(line: 83, scope: !42, inlinedAt: !44)
+!42 = distinct !DISubprogram(name: "<;", linkageName: "<", scope: !43, file: !43, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!43 = !DIFile(filename: "int.jl", directory: ".")
+!44 = !DILocation(line: 369, scope: !45, inlinedAt: !47)
+!45 = distinct !DISubprogram(name: ">;", linkageName: ">", scope: !46, file: !46, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!46 = !DIFile(filename: "operators.jl", directory: ".")
+!47 = !DILocation(line: 656, scope: !48, inlinedAt: !50)
+!48 = distinct !DISubprogram(name: "isempty;", linkageName: "isempty", scope: !49, file: !49, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!49 = !DIFile(filename: "range.jl", directory: ".")
+!50 = !DILocation(line: 881, scope: !51, inlinedAt: !52)
+!51 = distinct !DISubprogram(name: "iterate;", linkageName: "iterate", scope: !49, file: !49, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!52 = !DILocation(line: 5, scope: !4)
+!53 = !DILocation(line: 6, scope: !4)
+!54 = !DILocation(line: 8, scope: !4)
+!55 = !DILocation(line: 14, scope: !56, inlinedAt: !58)
+!56 = distinct !DISubprogram(name: "getindex;", linkageName: "getindex", scope: !57, file: !57, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!57 = !DIFile(filename: "essentials.jl", directory: ".")
+!58 = !DILocation(line: 7, scope: !4)
+!59 = !{!60, !60, i64 0}
+!60 = !{!"jtbaa_arraybuf", !39, i64 0}
+!61 = !DILocation(line: 971, scope: !62, inlinedAt: !58)
+!62 = distinct !DISubprogram(name: "setindex!;", linkageName: "setindex!", scope: !17, file: !17, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!63 = !DILocation(line: 499, scope: !23, inlinedAt: !64)
+!64 = !DILocation(line: 885, scope: !51, inlinedAt: !54)
+!65 = !DILocation(line: 11, scope: !4)
+!66 = !DILocation(line: 14, scope: !56, inlinedAt: !67)
+!67 = !DILocation(line: 10, scope: !4)
+!68 = !DILocation(line: 409, scope: !69, inlinedAt: !67)
+!69 = distinct !DISubprogram(name: "/;", linkageName: "/", scope: !70, file: !70, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!70 = !DIFile(filename: "float.jl", directory: ".")
+!71 = !DILocation(line: 971, scope: !62, inlinedAt: !67)
+!72 = !DILocation(line: 87, scope: !73, inlinedAt: !65)
+!73 = distinct !DISubprogram(name: "+;", linkageName: "+", scope: !43, file: !43, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!74 = !DILocation(line: 488, scope: !75, inlinedAt: !76)
+!75 = distinct !DISubprogram(name: "<=;", linkageName: "<=", scope: !43, file: !43, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!76 = !DILocation(line: 416, scope: !77, inlinedAt: !78)
+!77 = distinct !DISubprogram(name: ">=;", linkageName: ">=", scope: !46, file: !46, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!78 = !DILocation(line: 399, scope: !79, inlinedAt: !80)
+!79 = distinct !DISubprogram(name: "unitrange_last;", linkageName: "unitrange_last", scope: !49, file: !49, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!80 = !DILocation(line: 392, scope: !81, inlinedAt: !82)
+!81 = distinct !DISubprogram(name: "UnitRange;", linkageName: "UnitRange", scope: !49, file: !49, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!82 = !DILocation(line: 5, scope: !83, inlinedAt: !65)
+!83 = distinct !DISubprogram(name: "Colon;", linkageName: "Colon", scope: !49, file: !49, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!84 = !DILocation(line: 83, scope: !42, inlinedAt: !85)
+!85 = !DILocation(line: 369, scope: !45, inlinedAt: !86)
+!86 = !DILocation(line: 656, scope: !48, inlinedAt: !87)
+!87 = !DILocation(line: 881, scope: !51, inlinedAt: !65)
+!88 = !DILocation(line: 13, scope: !4)
+!89 = !DILocation(line: 14, scope: !56, inlinedAt: !90)
+!90 = !DILocation(line: 12, scope: !4)
+!91 = !DILocation(line: 408, scope: !92, inlinedAt: !90)
+!92 = distinct !DISubprogram(name: "*;", linkageName: "*", scope: !70, file: !70, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!93 = !DILocation(line: 407, scope: !94, inlinedAt: !90)
+!94 = distinct !DISubprogram(name: "-;", linkageName: "-", scope: !70, file: !70, type: !5, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !6)
+!95 = !DILocation(line: 971, scope: !62, inlinedAt: !90)
+!96 = !DILocation(line: 499, scope: !23, inlinedAt: !97)
+!97 = !DILocation(line: 885, scope: !51, inlinedAt: !88)
+!98 = !DILocation(line: 499, scope: !23, inlinedAt: !99)
+!99 = !DILocation(line: 885, scope: !51, inlinedAt: !100)
+!100 = !DILocation(line: 14, scope: !4)
+!101 = !DILocation(line: 499, scope: !23, inlinedAt: !102)
+!102 = !DILocation(line: 885, scope: !51, inlinedAt: !103)
+!103 = !DILocation(line: 15, scope: !4)
+!104 = !{!105, !105, i64 0}
+!105 = !{!"jtbaa_immut", !106, i64 0}
+!106 = !{!"jtbaa_value", !39, i64 0}

--- a/test/examples/triangular_solve.txt
+++ b/test/examples/triangular_solve.txt
@@ -1,0 +1,276 @@
+remark: REPL[26]:8:0: there are 16 scalar registers
+remark: REPL[26]:8:0: there are 32 vector registers
+
+
+
+
+
+
+
+
+remark: REPL[26]:8:0: Solved linear program:
+LoopBlock graph (#nodes = 2):
+v_0:
+mem =
+  %64 = load double, double addrspace(13)* %63, align 8, !dbg !55, !tbaa !59
+  store double %64, double addrspace(13)* %65, align 8, !dbg !61, !tbaa !59
+inNeighbors = 
+outNeighbors = v_1, 
+
+v_1:
+mem =
+  %83 = load double, double addrspace(13)* %82, align 8, !dbg !89, !tbaa !59
+  %87 = load double, double addrspace(13)* %86, align 8, !dbg !89, !tbaa !59
+  store double %89, double addrspace(13)* %82, align 8, !dbg !95, !tbaa !59
+inNeighbors = v_0, v_1, 
+outNeighbors = v_1, 
+
+
+LoopBlock Edges (#edges = 4):
+	Edge = Dependence Poly y -> x:
+	Input:
+Store:   store double %64, double addrspace(13)* %65, align 8, !dbg !61, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 2, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1 , i_0 ]
+Schedule Omega: [ 0, 0, 1 ]
+AffineLoopNest:
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -1 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+	Output:
+Load:   %83 = load double, double addrspace(13)* %82, align 8, !dbg !89, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+Schedule Omega: [ 0, 1, 0, 0 ]
+AffineLoopNest:
+Loop 2 lower bounds: i_2 >= 0
+Loop 2 upper bounds: i_2 <= -2 + %23 - i_1
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -2 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+Schedule In: nodeIndex = BitSet[0]
+ref = ArrayReference %55 (dim = 2, num loops: 2, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1 , i_0 ]
+s.getPhi()
+[  1  0
+   0  1 ]
+s.getFusionOmega() = [ 0, 0, 0 ]
+s.getOffsetOmega() = [ 1, 0 ]
+
+Schedule Out:
+nodeIndex = BitSet[1]; ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+	Edge = Dependence Poly y -> x:
+	Input:
+Store:   store double %64, double addrspace(13)* %65, align 8, !dbg !61, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 2, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1 , i_0 ]
+Schedule Omega: [ 0, 0, 1 ]
+AffineLoopNest:
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -1 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+	Output:
+Store:   store double %89, double addrspace(13)* %82, align 8, !dbg !95, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+Schedule Omega: [ 0, 1, 0, 2 ]
+AffineLoopNest:
+Loop 2 lower bounds: i_2 >= 0
+Loop 2 upper bounds: i_2 <= -2 + %23 - i_1
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -2 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+Schedule In: nodeIndex = BitSet[0]
+ref = ArrayReference %55 (dim = 2, num loops: 2, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1 , i_0 ]
+s.getPhi()
+[  1  0
+   0  1 ]
+s.getFusionOmega() = [ 0, 0, 0 ]
+s.getOffsetOmega() = [ 1, 0 ]
+
+Schedule Out:
+nodeIndex = BitSet[1]; ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+	Edge = Dependence Poly y -> x:
+	Input:
+Load:   %83 = load double, double addrspace(13)* %82, align 8, !dbg !89, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+Schedule Omega: [ 0, 1, 0, 0 ]
+AffineLoopNest:
+Loop 2 lower bounds: i_2 >= 0
+Loop 2 upper bounds: i_2 <= -2 + %23 - i_1
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -2 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+	Output:
+Store:   store double %89, double addrspace(13)* %82, align 8, !dbg !95, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+Schedule Omega: [ 0, 1, 0, 2 ]
+AffineLoopNest:
+Loop 2 lower bounds: i_2 >= 0
+Loop 2 upper bounds: i_2 <= -2 + %23 - i_1
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -2 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+Schedule In: nodeIndex = BitSet[1]
+ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+
+Schedule Out:
+nodeIndex = BitSet[1]; ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+	Edge = Dependence Poly x -> y:
+	Input:
+Store:   store double %89, double addrspace(13)* %82, align 8, !dbg !95, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+Schedule Omega: [ 0, 1, 0, 2 ]
+AffineLoopNest:
+Loop 2 lower bounds: i_2 >= 0
+Loop 2 upper bounds: i_2 <= -2 + %23 - i_1
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -2 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+	Output:
+Load:   %83 = load double, double addrspace(13)* %82, align 8, !dbg !89, !tbaa !59
+ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+Schedule Omega: [ 0, 1, 0, 0 ]
+AffineLoopNest:
+Loop 2 lower bounds: i_2 >= 0
+Loop 2 upper bounds: i_2 <= -2 + %23 - i_1
+Loop 1 lower bounds: i_1 >= 0
+Loop 1 upper bounds: i_1 <= -2 + %23
+Loop 0 lower bounds: i_0 >= 0
+Loop 0 upper bounds: i_0 <= -1 + %20
+
+Schedule In: nodeIndex = BitSet[1]
+ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+
+Schedule Out:
+nodeIndex = BitSet[1]; ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+LoopBlock schedule (#mem accesses = 5):
+
+Ref = ArrayReference %52 (dim = 2, num loops: 2, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1 , i_0 ]
+nodeIndex = 0
+s.getPhi()
+[  1  0
+   0  1 ]
+s.getFusionOmega() = [ 0, 0, 0 ]
+s.getOffsetOmega() = [ 1, 0 ]
+Ref = ArrayReference %55 (dim = 2, num loops: 2, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1 , i_0 ]
+nodeIndex = 0
+s.getPhi()
+[  1  0
+   0  1 ]
+s.getFusionOmega() = [ 0, 0, 0 ]
+s.getOffsetOmega() = [ 1, 0 ]
+Ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+nodeIndex = 1
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+Ref = ArrayReference %58 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %23 ]
+Subscripts: [ i_1  + i_2  + 1, i_1 ]
+nodeIndex = 1
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+Ref = ArrayReference %55 (dim = 2, num loops: 3, element size: 8):
+Sizes: [ unknown, %20 ]
+Subscripts: [ i_1  + i_2  + 1, i_0 ]
+nodeIndex = 1
+s.getPhi()
+[  1  1  0
+   0  0  1
+   0  1  0 ]
+s.getFusionOmega() = [ 0, 0, 0, 0 ]
+s.getOffsetOmega() = [ 0, 0, 0 ]
+
+
+

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -1,6 +1,5 @@
 #include "../include/BitSets.hpp"
 #include "../include/Graphs.hpp"
-#include "../include/Macro.hpp"
 #include "../include/Math.hpp"
 #include <algorithm>
 #include <cstdint>
@@ -96,7 +95,6 @@ TEST(GraphTest, BasicAssertions) {
   auto scc0 = Graphs::stronglyConnectedComponents(G);
   auto scc1 = Graphs::stronglyConnectedComponents(G);
   EXPECT_EQ(scc0, scc1);
-  SHOWLN(scc0.size());
   for (auto &v : scc0)
     llvm::errs() << "SCC: " << v << "\n";
   // NOTE: currently using inNeighbors instead of outNeighbors, so in

--- a/test/normal_form_test.cpp
+++ b/test/normal_form_test.cpp
@@ -48,12 +48,8 @@ TEST(OrthogonalizeTest, BasicAssertions) {
       LinearAlgebra::printVector(llvm::errs() << "included = ", included)
         << "\n";
       if (auto optlu = LU::fact(K)) {
-        SHOWLN(K);
         if (auto optA2 = (*optlu).inv()) {
           SquareMatrix<Rational> &A2 = *optA2;
-          SHOWLN(A2);
-          SHOWLN(B);
-
           for (size_t n = 0; n < 4; ++n) {
             for (size_t j = 0; j < included.size(); ++j) {
               llvm::errs() << "A2(" << n << ", " << j << ") = " << A2(n, j)

--- a/test/orthogonalize_test.cpp
+++ b/test/orthogonalize_test.cpp
@@ -60,8 +60,6 @@ orthogonalize(llvm::SmallVectorImpl<ArrayReference *> const &ai)
   // (A*K')*J <= r
   IntMatrix AK{alnp.A};
   AK(_, _(numSymbols, end)) = alnp.A(_, _(numSymbols, end)) * K.transpose();
-  SHOWLN(alnp.A(_, _(numSymbols, end)));
-  SHOWLN(AK(_, _(numSymbols, end)));
   AffineLoopNest<true> alnNew{std::move(AK), alnp.S};
   alnNew.pruneBounds();
   IntMatrix KS{K * S};
@@ -156,7 +154,6 @@ TEST(OrthogonalizeTest, BasicAssertions) {
   llvm::SmallVector<ArrayReference, 0> &newArrayRefs = orth->second;
   for (auto &&ar : newArrayRefs)
     ar.loop = &newAln;
-  SHOWLN(newArrayRefs.size());
   EXPECT_EQ(countNonZero(newArrayRefs[0].indexMatrix()(_, 0)), 1);
   EXPECT_EQ(countNonZero(newArrayRefs[0].indexMatrix()(_, 1)), 1);
   EXPECT_EQ(countNonZero(newArrayRefs[1].indexMatrix()(_, 0)), 1);
@@ -182,11 +179,8 @@ TEST(OrthogonalizeTest, BasicAssertions) {
   EXPECT_EQ(loop0Count.first, 1);
   EXPECT_EQ(loop0Count.second, 0);
   llvm::errs() << "New ArrayReferences:\n";
-  for (auto &ar : newArrayRefs) {
-    SHOW(ar.indexMatrix().numRow());
-    CSHOWLN(ar.indexMatrix().numCol());
+  for (auto &ar : newArrayRefs)
     llvm::errs() << ar << "\n";
-  }
 }
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
@@ -282,20 +276,16 @@ TEST(BadMul, BasicAssertions) {
   for (auto &ar : newArrayRefs)
     ar.loop = &newAln;
 
-  SHOWLN(aln.A);
-  SHOWLN(newAln.A);
   // llvm::errs() << "b=" << PtrVector<MPoly>(newAln.aln->b);
   llvm::errs() << "Skewed loop nest:\n" << newAln << "\n";
   auto loop2Count = countSigns(newAln.A, 2 + newAln.getNumSymbols());
   EXPECT_EQ(loop2Count.first, 1);
   EXPECT_EQ(loop2Count.second, 0);
   newAln.removeLoopBang(2);
-  SHOWLN(newAln.A);
   auto loop1Count = countSigns(newAln.A, 1 + newAln.getNumSymbols());
   EXPECT_EQ(loop1Count.first, 1);
   EXPECT_EQ(loop1Count.second, 0);
   newAln.removeLoopBang(1);
-  SHOWLN(newAln.A);
   auto loop0Count = countSigns(newAln.A, 0 + newAln.getNumSymbols());
   EXPECT_EQ(loop0Count.first, 1);
   EXPECT_EQ(loop0Count.second, 0);

--- a/test/remarks_test.cpp
+++ b/test/remarks_test.cpp
@@ -1,19 +1,66 @@
+#include <array>
 #include <cstdio>
-#include <gtest/gtest.h>
+#include <cstring>
+#include <string>
+// #include <gtest/gtest.h>
 
-// NOLINTNEXTLINE(modernize-use-trailing-return-type)
-TEST(Remarks, BasicAssertions) {
-  FILE *fpopt = popen("opt -mcpu=skylake-avx512 --disable-output -load-pass-plugin=./libTurboLoop.so -passes='turbo-loop' -pass-remarks-analysis='turbo-loop' ./examples/triangular_solve.ll", "r");
-  FILE *fptxt = fopen("./examples/triangular_solve.txt", "r");
+auto main(int argc, char **argv) -> int {
+  if (argc != 3)
+    return 1000;
+  std::string modulePath = argv[1];
+  std::string examplesPath = argv[2];
+  // puts(modulePath.c_str());
+  // puts(examplesPath.c_str());
+  std::string fileRoot = examplesPath + std::string("/triangular_solve.");
+  auto cmd =
+    std::string(
+      "opt -mcpu=skylake-avx512 --disable-output -load-pass-plugin=") +
+    modulePath +
+    std::string(" -passes='turbo-loop' -pass-remarks-analysis='turbo-loop' ") +
+    fileRoot + std::string("ll 2>&1");
+  // puts(cmd.c_str());
+  std::string txtfile = fileRoot + std::string("txt");
+
+  FILE *fpopt = popen(cmd.c_str(), "r");
+  FILE *fptxt = fopen(txtfile.c_str(), "r");
   std::array<char, 128> bufopt;
   std::array<char, 128> buftxt;
-  
+
+  int count = 0;
   while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr) {
-    EXPECT_NE(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
-    EXPECT_STREQ(buftxt.data(), bufopt.data());
+    if (fgets(buftxt.data(), sizeof(buftxt), fptxt) == nullptr)
+      return 1001;
+    if (int diff = strcmp(bufopt.data(), buftxt.data()))
+      return diff;
+    ++count;
   }
+  if (count < 276)
+    return 1002;
   // should be done
-  EXPECT_EQ(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
-  EXPECT_EQ(fclose(fptxt), 0);
-  EXPECT_EQ(pclose(fpopt), 0);
+  if (fgets(buftxt.data(), sizeof(buftxt), fptxt) != nullptr)
+    return 1003;
+  if (pclose(fpopt) != 0)
+    return 1004;
+  if (fclose(fptxt) != 0)
+    return 1005;
+  return 0;
 }
+
+// // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+// TEST(Remarks, BasicAssertions) {
+//   FILE *fpopt = popen("opt -mcpu=skylake-avx512 --disable-output
+//   -load-pass-plugin=./libTurboLoop.so -passes='turbo-loop'
+//   -pass-remarks-analysis='turbo-loop' ./examples/triangular_solve.ll", "r");
+//   FILE *fptxt = fopen("./examples/triangular_solve.txt", "r");
+//   std::array<char, 128> bufopt;
+//   std::array<char, 128> buftxt;
+
+//   while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr) {
+//     EXPECT_NE(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
+//     EXPECT_STREQ(buftxt.data(), bufopt.data());
+//   }
+//   // should be done
+//   EXPECT_EQ(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
+//   EXPECT_EQ(fclose(fptxt), 0);
+//   EXPECT_EQ(pclose(fpopt), 0);
+// }

--- a/test/remarks_test.cpp
+++ b/test/remarks_test.cpp
@@ -2,7 +2,6 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
-// #include <gtest/gtest.h>
 
 auto main(int argc, char **argv) -> int {
   if (argc != 3)
@@ -45,22 +44,3 @@ auto main(int argc, char **argv) -> int {
     return 1005;
   return 0;
 }
-
-// // NOLINTNEXTLINE(modernize-use-trailing-return-type)
-// TEST(Remarks, BasicAssertions) {
-//   FILE *fpopt = popen("opt -mcpu=skylake-avx512 --disable-output
-//   -load-pass-plugin=./libTurboLoop.so -passes='turbo-loop'
-//   -pass-remarks-analysis='turbo-loop' ./examples/triangular_solve.ll", "r");
-//   FILE *fptxt = fopen("./examples/triangular_solve.txt", "r");
-//   std::array<char, 128> bufopt;
-//   std::array<char, 128> buftxt;
-
-//   while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr) {
-//     EXPECT_NE(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
-//     EXPECT_STREQ(buftxt.data(), bufopt.data());
-//   }
-//   // should be done
-//   EXPECT_EQ(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
-//   EXPECT_EQ(fclose(fptxt), 0);
-//   EXPECT_EQ(pclose(fpopt), 0);
-// }

--- a/test/remarks_test.cpp
+++ b/test/remarks_test.cpp
@@ -1,0 +1,19 @@
+#include <cstdio>
+#include <gtest/gtest.h>
+
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
+TEST(Remarks, BasicAssertions) {
+  FILE *fpopt = popen("opt -mcpu=skylake-avx512 --disable-output -load-pass-plugin=./libTurboLoop.so -passes='turbo-loop' -pass-remarks-analysis='turbo-loop' ./examples/triangular_solve.ll", "r");
+  FILE *fptxt = fopen("./examples/triangular_solve.txt", "r");
+  std::array<char, 128> bufopt;
+  std::array<char, 128> buftxt;
+  
+  while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr) {
+    EXPECT_NE(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
+    EXPECT_STREQ(buftxt.data(), bufopt.data());
+  }
+  // should be done
+  EXPECT_EQ(fgets(buftxt.data(), sizeof(buftxt), fptxt), nullptr);
+  EXPECT_EQ(fclose(fptxt), 0);
+  EXPECT_EQ(pclose(fpopt), 0);
+}

--- a/test/remarks_test.cpp
+++ b/test/remarks_test.cpp
@@ -26,15 +26,22 @@ auto main(int argc, char **argv) -> int {
   std::array<char, 128> buftxt;
 
   int count = 0;
+  int failed = -1;
   while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr) {
     if (fgets(buftxt.data(), sizeof(buftxt), fptxt) == nullptr)
       return 1001;
     if (int diff = strcmp(bufopt.data(), buftxt.data())) {
-      printf("line %d differed at %d\nopt: %s\ntxt: %s\n", count, diff,
+      printf("line %d differed at %d\ntxt: %s\nopt:\n%s\n", count, diff,
              bufopt.data(), buftxt.data());
-      return diff;
+      failed = count;
+      break;
     }
     ++count;
+  }
+  if (failed >= 0) {
+    while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr)
+      puts(bufopt.data());
+    return ++failed;
   }
   if (count < 276)
     return 1002;

--- a/test/remarks_test.cpp
+++ b/test/remarks_test.cpp
@@ -8,8 +8,8 @@ auto main(int argc, char **argv) -> int {
     return 1000;
   std::string modulePath = argv[1];
   std::string examplesPath = argv[2];
-  // puts(modulePath.c_str());
-  // puts(examplesPath.c_str());
+  printf("modulePath: %s\n", modulePath.c_str());
+  printf("examplesPath: %s\n", examplesPath.c_str());
   std::string fileRoot = examplesPath + std::string("/triangular_solve.");
   auto cmd =
     std::string(
@@ -17,7 +17,7 @@ auto main(int argc, char **argv) -> int {
     modulePath +
     std::string(" -passes='turbo-loop' -pass-remarks-analysis='turbo-loop' ") +
     fileRoot + std::string("ll 2>&1");
-  // puts(cmd.c_str());
+  printf("cmd: %s", cmd.c_str());
   std::string txtfile = fileRoot + std::string("txt");
 
   FILE *fpopt = popen(cmd.c_str(), "r");
@@ -29,8 +29,11 @@ auto main(int argc, char **argv) -> int {
   while (fgets(bufopt.data(), sizeof(bufopt), fpopt) != nullptr) {
     if (fgets(buftxt.data(), sizeof(buftxt), fptxt) == nullptr)
       return 1001;
-    if (int diff = strcmp(bufopt.data(), buftxt.data()))
+    if (int diff = strcmp(bufopt.data(), buftxt.data())) {
+      printf("line %d differed at %d\nopt: %s\ntxt: %s\n", count, diff,
+             bufopt.data(), buftxt.data());
       return diff;
+    }
     ++count;
   }
   if (count < 276)

--- a/test/remarks_test.cpp
+++ b/test/remarks_test.cpp
@@ -32,7 +32,7 @@ auto main(int argc, char **argv) -> int {
       return 1001;
     if (int diff = strcmp(bufopt.data(), buftxt.data())) {
       printf("line %d differed at %d\ntxt: %s\nopt:\n%s\n", count, diff,
-             bufopt.data(), buftxt.data());
+             buftxt.data(), bufopt.data());
       failed = count;
       break;
     }

--- a/test/simplex_test.cpp
+++ b/test/simplex_test.cpp
@@ -1,16 +1,17 @@
+#include "../include/Math.hpp"
+#include "../include/MatrixStringParse.hpp"
 #include "../include/Simplex.hpp"
-#include "Macro.hpp"
-#include "Math.hpp"
-#include "MatrixStringParse.hpp"
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <numeric>
 
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(SimplexTest, BasicAssertions) {
   IntMatrix A{stringToIntMatrix("[10 3 2 1; 15 2 5 3]")};
   IntMatrix B{0, 4};
   std::optional<Simplex> optS{Simplex::positiveVariables(A, B)};
   EXPECT_TRUE(optS.has_value());
+  assert(optS.has_value());
   Simplex &S{*optS};
   auto C{S.getCost()};
   C[0] = 0;
@@ -22,6 +23,7 @@ TEST(SimplexTest, BasicAssertions) {
   llvm::errs() << "S.tableau =" << S.tableau << "\n";
   EXPECT_EQ(S.run(), 20);
 }
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(LexMinSimplexTest, BasicAssertions) {
   IntMatrix tableau{stringToIntMatrix(
     "[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
@@ -940,13 +942,10 @@ TEST(LexMinSimplexTest, BasicAssertions) {
 
   tableau(_(0, 2), _) = -5859553999884210514;
   Simplex simp{tableau};
-  // SHOWLN(simp);
   Vector<Rational> sol(37);
-  SHOWLN(sol);
   EXPECT_EQ(sol.size(), 37);
   EXPECT_FALSE(simp.initiateFeasible());
   simp.lexMinimize(sol);
-  SHOWLN(sol);
   size_t solSum = 0;
   for (auto s : sol) {
     solSum += s.numerator;
@@ -964,7 +963,6 @@ TEST(LexMinSimplexTest, BasicAssertions) {
     C(_(37, end)) = 0;
     EXPECT_EQ(simp.run(), -3);
     Vector<Rational> sol2 = simp.getSolution();
-    SHOWLN(sol2(_(begin, 38)));
     size_t sum = 0;
     for (size_t i = 0; i < 38; ++i) {
       Rational r = sol2(i);
@@ -985,7 +983,6 @@ TEST(LexMinSimplexTest, BasicAssertions) {
     C(_(37, end)) = 0;
     EXPECT_EQ(simp2.run(), -3);
     Vector<Rational> sol2 = simp2.getSolution();
-    SHOWLN(sol2(_(begin, 38)));
     size_t sum = 0;
     Rational rsum = 0; // test summing rationals
     for (size_t i = 0; i < 38; ++i) {
@@ -1000,6 +997,7 @@ TEST(LexMinSimplexTest, BasicAssertions) {
       EXPECT_EQ(sol2(i), (i == 29) || (i == 31) || (i == 34));
   }
 }
+// NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(LexMinSimplexTest2, BasicAssertions) {
   IntMatrix tableau{stringToIntMatrix(
     "[140296676906080 140296676906080 94205055383680 94205055383680 0 0 0 "
@@ -1197,13 +1195,10 @@ TEST(LexMinSimplexTest2, BasicAssertions) {
     "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
     "-1]")};
   Simplex simp{tableau};
-  // SHOWLN(simp);
   Vector<Rational> sol(15);
-  SHOWLN(sol);
   EXPECT_EQ(sol.size(), 15);
   EXPECT_FALSE(simp.initiateFeasible());
   simp.lexMinimize(sol);
-  SHOWLN(sol);
   size_t solSum = 0;
   for (size_t i = 0; i < 10; ++i) {
     solSum += sol[i].numerator;
@@ -1227,7 +1222,6 @@ TEST(LexMinSimplexTest2, BasicAssertions) {
     C(_(11, end)) = 0;
     EXPECT_EQ(simp.run(), 0);
     Vector<Rational> sol2 = simp.getSolution();
-    SHOWLN(sol2(_(begin, 15)));
     size_t sum = 0;
     for (size_t i = 0; i < 10; ++i) {
       Rational r = sol2(i);
@@ -1238,28 +1232,4 @@ TEST(LexMinSimplexTest2, BasicAssertions) {
     // for (size_t i = 0; i < 37; ++i)
     //     EXPECT_EQ(sol2(i), (i == 29) || (i == 31) || (i == 34));
   }
-  // {
-  //     // test new simplex
-  //     Simplex simp2{tableau};
-  //     EXPECT_FALSE(simp2.initiateFeasible());
-  //     auto C{simp2.getCost()};
-  //     C(0) = 0;
-  //     C(_(1, 37)) = 1;
-  //     C(_(37, end)) = 0;
-  //     EXPECT_EQ(simp2.run(), -3);
-  //     Vector<Rational> sol2 = simp2.getSolution();
-  //     SHOWLN(sol2(_(begin, 38)));
-  //     size_t sum = 0;
-  //     Rational rsum = 0; // test summing rationals
-  //     for (size_t i = 0; i < 38; ++i) {
-  //         Rational r = sol2(i);
-  //         sum += r.numerator;
-  //         EXPECT_EQ(r.denominator, 1);
-  //         rsum += r;
-  //     }
-  //     EXPECT_EQ(sum, 3);
-  //     EXPECT_EQ(rsum, 3);
-  //     for (size_t i = 0; i < 37; ++i)
-  //         EXPECT_EQ(sol2(i), (i == 29) || (i == 31) || (i == 34));
-  // }
 }


### PR DESCRIPTION
Adding `-pass-remarks-analysis="turbo-loop"` to `opt`, e.g.
```sh
opt -mcpu=native --disable-output -load-pass-plugin=/home/chriselrod/Documents/progwork/cxx/LoopModels/builddirgcc/libTurboLoop.so -passes="turbo-loop" -pass-remarks-analysis="turbo-loop"  /home/chriselrod/Documents/progwork/cxx/LoopPlayground/LoopInductTests/test/triangular_solve.ll
```
will make it emit turbo-loop analysis remarks.

My plan before merging this PR is to
- [x] Remove all print statements from running `opt`.
- [x] Replacing some of them with remarks.
- [x] Add a few `.ll` test files.
- [x] Add tests using [popen](https://pubs.opengroup.org/onlinepubs/9699919799/functions/popen.html) to execute `opt`, and then check the emitted remarks. This will serve the dual purposes of testing the remarks, and -- more importantly -- allowing us to test the analysis/interpretation of LLVM IR.

Eventually, once we start emitting LLVM IR, we'll use [llvm-lit](https://llvm.org/docs/CommandGuide/lit.html) for testing the pass. But I think this is a reasonable stopgap.