### PR TITLE
RelWithDebug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - run: cmake --build build/test --target test
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-    - run: cmake -G Ninja -S test -B builddirclang/test -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER='Undefined' -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_TEST_COVERAGE=1
+    - run: cmake -G Ninja -S test -B builddirclang/test -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_SANITIZER='Undefined' -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_TEST_COVERAGE=1
       env:
         CXX: clang++-15
     - run: cmake --build builddirclang/test


### PR DESCRIPTION
Maybe optimizing away some branches will change the reported codecov, reducing the amount of partials?