### PR TITLE
Exclude unreachables from gcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - run: cmake --build builddirclang/test --target test
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-    - run: gcovr --xml=coverage.xml --json=coverage.json --txt=coverage.txt
+    - run: gcovr --exclude-throw-branches --exclude-unreachable-branches --xml=coverage.xml --json=coverage.json --txt=coverage.txt
     - uses: codecov/codecov-action@v3
       with:
         files: coverage.xml, coverage.json, coverage.txt
@@ -61,7 +61,7 @@ jobs:
     # - run: cmake --build builddirgcc/test --target test
     #   env:
     #     CTEST_OUTPUT_ON_FAILURE: 1
-    - run: gcovr --xml=coverage.xml --json=coverage.json --txt=coverage.txt
+    - run: gcovr --exclude-throw-branches --exclude-unreachable-branches --xml=coverage.xml --json=coverage.json --txt=coverage.txt
     - uses: codecov/codecov-action@v3
       with:
         files: coverage.xml, coverage.json, coverage.txt


### PR DESCRIPTION
Might produce "more sensible" coverage reports
https://gcovr.com/en/5.0/guide.html#cmdoption-gcovr-exclude-unreachable-branches