### PR TITLE
make test exceptions optional and disable in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
         sudo ./llvm.sh 15 all
         sudo apt install g++-12 libgtest-dev ninja-build pkg-config cmake gcovr
         sudo ln -s $(which opt-15) /usr/local/bin/opt
-    - run: ./configure.debug
+    - run: ./configure.debug -DENABLE_TEST_EXCEPTIONS=OFF
       env:
         CXX: g++-12
     - run: cmake --build build/test
     - run: cmake --build build/test --target test
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-    - run: cmake -G Ninja -S test -B builddirclang/test -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_SANITIZER='Undefined' -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_TEST_COVERAGE=1
+    - run: cmake -G Ninja -S test -B builddirclang/test -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_SANITIZER='Undefined' -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_TEST_COVERAGE=1 -DENABLE_TEST_EXCEPTIONS=OFF
       env:
         CXX: clang++-15
     - run: cmake --build builddirclang/test
@@ -38,7 +38,7 @@ jobs:
     - run: brew install llvm@15 ninja pkg-config cmake gcovr # gcc
     - run: echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
     - run: echo $(which clang++)
-    - run: ./configure.debug -DCMAKE_PREFIX_PATH=/usr/local
+    - run: ./configure.debug -DCMAKE_PREFIX_PATH=/usr/local -DENABLE_TEST_EXCEPTIONS=OFF
       env:
         CXX: clang++
         LDFLAGS: "-L/usr/local/opt/llvm/lib/c++ -Wl,-rpath,/usr/local/opt/llvm/lib/c++ -L/usr/local/opt/llvm/lib"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ project(LoopModelsTests LANGUAGES CXX)
 # ---- Options ----
 
 option(ENABLE_TEST_COVERAGE "Enable test coverage" OFF)
+option(ENABLE_TEST_EXCEPTIONS "Enable test coverage" ON)
 option(TEST_INSTALLED_VERSION "Test the version found by find_package" OFF)
 
 # --- Import tools ----
@@ -61,6 +62,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   WORKING_DIRECTORY=${PROJECT_BINARY_DIR}
 )
 
+target_compile_options(${PROJECT_NAME} PRIVATE -fno-rtti)
+if (ENABLE_TEST_EXCEPTIONS)
+  target_compile_options(${PROJECT_NAME} PRIVATE -fexceptions)
+else()
+  target_compile_options(${PROJECT_NAME} PRIVATE -fno-exceptions)
+endif()
+
 # enable compiler warnings
 if(NOT TEST_INSTALLED_VERSION)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
@@ -68,7 +76,7 @@ if(NOT TEST_INSTALLED_VERSION)
     # target_compile_options(LoopModels PUBLIC -Wall -Wpedantic -Wextra -Werror)
   elseif(MSVC)
     target_compile_options(LoopModels PUBLIC /W4 /WX)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC DOCTEST_CONFIG_USE_STD_HEADERS)
+    # target_compile_definitions(${PROJECT_NAME} PUBLIC DOCTEST_CONFIG_USE_STD_HEADERS)
   endif()
 endif()
 


### PR DESCRIPTION
Maybe it improves coverage by simplifying branches.

Perhaps exceptions, because they could theoretically be caught, count as control flow and therefore mark the lines as partial.